### PR TITLE
fix: return 404 on favicon and robots paths

### DIFF
--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -315,8 +315,15 @@ module FunctionsFramework
 
     ## @private
     class AppBase
+      BLACKLISTED_PATHS = ["/favicon.ico", "/robots.txt"].freeze
+
       def initialize config
         @config = config
+      end
+
+      def blacklisted_path? env
+        path = env[::Rack::SCRIPT_NAME].to_s + env[::Rack::PATH_INFO].to_s
+        BLACKLISTED_PATHS.include? path
       end
 
       def interpret_response response
@@ -338,6 +345,10 @@ module FunctionsFramework
           error = error_message e
           string_response error, "text/plain", 500
         end
+      end
+
+      def notfound_response
+        string_response "Not found", "text/plain", 404
       end
 
       def string_response string, content_type, status
@@ -373,6 +384,7 @@ module FunctionsFramework
       end
 
       def call env
+        return notfound_response if blacklisted_path? env
         response =
           begin
             logger = env["rack.logger"] = @config.logger
@@ -395,6 +407,7 @@ module FunctionsFramework
       end
 
       def call env
+        return notfound_response if blacklisted_path? env
         logger = env["rack.logger"] = @config.logger
         event =
           begin

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -83,7 +83,7 @@ describe FunctionsFramework::Server do
 
   it "handles post requests" do
     response = query_server_with_retry do
-      ::Net::HTTP.post URI(server_url), "Hello, world!", {"Content-Type" => "text/plain"}
+      ::Net::HTTP.post URI("#{server_url}/"), "Hello, world!", {"Content-Type" => "text/plain"}
     end
     assert_equal "200", response.code
     assert_equal "Received: \"Hello, world!\"", response.body
@@ -91,7 +91,7 @@ describe FunctionsFramework::Server do
 
   it "handles get requests" do
     response = query_server_with_retry do
-      ::Net::HTTP.get_response URI(server_url)
+      ::Net::HTTP.get_response URI("#{server_url}/")
     end
     assert_equal "200", response.code
     assert_equal "Received: \"\"", response.body


### PR DESCRIPTION
The server should return a 404 when receiving a request for `/favicon.ico` or `/robots.txt` according to a recent update to the spec.