### PR TITLE
feat: Support converting legacy events for pubsub, storage, and firestore

### DIFF
--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -16,6 +16,7 @@ require "logger"
 
 require "functions_framework/cloud_events"
 require "functions_framework/function"
+require "functions_framework/legacy_events"
 require "functions_framework/registry"
 require "functions_framework/version"
 

--- a/lib/functions_framework/cloud_events.rb
+++ b/lib/functions_framework/cloud_events.rb
@@ -78,10 +78,11 @@ module FunctionsFramework
       #     includes a single structured or binary event
       # @return [Array<FunctionsFramework::CloudEvents::Event>] if the request
       #     includes a batch of structured events
+      # @return [nil] if the request is not a CloudEvent.
       #
       def decode_rack_env env
         content_type_header = env["CONTENT_TYPE"]
-        raise "Missing content-type header" unless content_type_header
+        return nil unless content_type_header
         content_type = ContentType.new content_type_header
         if content_type.media_type == "application"
           case content_type.subtype_prefix

--- a/lib/functions_framework/cloud_events/binary_content.rb
+++ b/lib/functions_framework/cloud_events/binary_content.rb
@@ -26,12 +26,15 @@ module FunctionsFramework
         # @param env [Hash] Rack environment hash
         # @param content_type [FunctionsFramework::CloudEvents::ContentType]
         #     the content type from the Rack environment
-        # @return [FunctionsFramework::CloudEvents::Event]
+        # @return [FunctionsFramework::CloudEvents::Event] if a CloudEvent
+        #     could be decoded from the Rack environment
+        # @return [nil] if the Rack environment does not indicate a CloudEvent
         #
         def decode_rack_env env, content_type
-          data = env["rack.input"]&.read
           spec_version = interpret_header env, "HTTP_CE_SPECVERSION"
+          return nil if spec_version.nil?
           raise "Unrecognized specversion: #{spec_version}" unless spec_version == "1.0"
+          data = env["rack.input"]&.read
           Event.new \
             id:                interpret_header(env, "HTTP_CE_ID"),
             source:            interpret_header(env, "HTTP_CE_SOURCE"),

--- a/lib/functions_framework/legacy_events.rb
+++ b/lib/functions_framework/legacy_events.rb
@@ -1,0 +1,117 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "json"
+require "securerandom"
+
+module FunctionsFramework
+  ##
+  # Converter from legacy GCF event formats to CloudEvents.
+  #
+  module LegacyEvents
+    class << self
+      ##
+      # Decode an event from the given Rack environment hash.
+      #
+      # @param env [Hash] The Rack environment
+      # @return [FunctionsFramework::CloudEvents::Event] if the request could
+      #     be converted
+      # @return [nil] if the event format was not recognized.
+      #
+      def decode_rack_env env
+        content_type = CloudEvents::ContentType.new env["CONTENT_TYPE"]
+        charset = content_type.charset
+        input = env["rack.input"]
+        input = input.read if input.respond_to? :read
+        input = input.encode charset if charset
+        input = ::JSON.parse input
+        decode_storage(input) ||
+          decode_pubsub(input) ||
+          decode_firestore(input) ||
+          decode_storage_legacy(input) ||
+          decode_pubsub_legacy(input)
+      rescue ::JSON::ParserError
+        nil
+      end
+
+      private
+
+      def decode_storage input
+        context = input["context"]
+        return nil unless context
+        return nil unless context["eventType"]&.start_with? "google.storage."
+        resource = context["resource"]
+        return nil unless resource && resource["service"] && resource["name"]
+        return nil unless resource["type"] == "storage#object"
+        CloudEvents::Event.new id:           ::SecureRandom.uuid,
+                               source:       "//#{resource['service']}/#{resource['name']}",
+                               type:         "#{context['eventType']}.v1",
+                               spec_version: "1.0",
+                               data:         input["data"],
+                               time:         context["timestamp"]
+      end
+
+      def decode_pubsub input
+        context = input["context"]
+        return nil unless context
+        return nil unless context["eventType"]&.start_with? "google.pubsub."
+        resource = context["resource"]
+        return nil unless resource && resource["service"] && resource["name"]
+        return nil unless resource["type"] == "type.googleapis.com/google.pubsub.v1.PubsubMessage"
+        CloudEvents::Event.new id:           ::SecureRandom.uuid,
+                               source:       "//#{resource['service']}/#{resource['name']}",
+                               type:         "#{context['eventType']}.v1",
+                               spec_version: "1.0",
+                               data:         input["data"],
+                               time:         context["timestamp"]
+      end
+
+      def decode_firestore input
+        return nil unless input["resource"] && input["data"] && input["timestamp"]
+        pre, event_type = input["eventType"].to_s.split "providers/cloud.firestore/eventTypes/"
+        return nil unless pre == "" && event_type && !event_type.empty?
+        CloudEvents::Event.new id:           ::SecureRandom.uuid,
+                               source:       "//firestore.googleapis.com/#{input['resource']}",
+                               type:         "google.firestore.#{event_type}.v1",
+                               spec_version: "1.0",
+                               data:         input["data"],
+                               time:         input["timestamp"]
+      end
+
+      def decode_storage_legacy input
+        return nil unless input["resource"] && input["data"] && input["timestamp"]
+        pre, event_type = input["eventType"].to_s.split "providers/cloud.storage/eventTypes/"
+        return nil unless pre == "" && event_type && !event_type.empty?
+        CloudEvents::Event.new id:           ::SecureRandom.uuid,
+                               source:       "//storage.googleapis.com/#{input['resource']}",
+                               type:         "google.storage.#{event_type}.v1",
+                               spec_version: "1.0",
+                               data:         input["data"],
+                               time:         input["timestamp"]
+      end
+
+      def decode_pubsub_legacy input
+        return nil unless input["resource"] && input["data"] && input["timestamp"]
+        pre, event_type = input["eventType"].to_s.split "providers/cloud.pubsub/eventTypes/"
+        return nil unless pre == "" && event_type && !event_type.empty?
+        CloudEvents::Event.new id:           ::SecureRandom.uuid,
+                               source:       "//pubsub.googleapis.com/#{input['resource']}",
+                               type:         "google.pubsub.#{event_type}.v1",
+                               spec_version: "1.0",
+                               data:         input["data"],
+                               time:         input["timestamp"]
+      end
+    end
+  end
+end

--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -411,7 +411,9 @@ module FunctionsFramework
         logger = env["rack.logger"] = @config.logger
         event =
           begin
-            CloudEvents.decode_rack_env env
+            CloudEvents.decode_rack_env(env) ||
+              LegacyEvents.decode_rack_env(env) ||
+              raise("Unknown event type")
           rescue ::StandardError => e
             e
           end

--- a/test/legacy_events_data/firestore_simple.json
+++ b/test/legacy_events_data/firestore_simple.json
@@ -1,0 +1,51 @@
+{
+   "data":{
+      "oldValue":{
+         "createTime":"2020-04-23T09:58:53.211035Z",
+         "fields":{
+            "another test":{
+               "stringValue":"asd"
+            },
+            "count":{
+               "integerValue":"3"
+            },
+            "foo":{
+               "stringValue":"bar"
+            }
+         },
+         "name":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+         "updateTime":"2020-04-23T12:00:27.247187Z"
+      },
+      "updateMask":{
+         "fieldPaths":[
+            "count"
+         ]
+      },
+      "value":{
+         "createTime":"2020-04-23T09:58:53.211035Z",
+         "fields":{
+            "another test":{
+               "stringValue":"asd"
+            },
+            "count":{
+               "integerValue":"4"
+            },
+            "foo":{
+               "stringValue":"bar"
+            }
+         },
+         "name":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+         "updateTime":"2020-04-23T12:00:27.247187Z"
+      }
+   },
+   "eventId":"7b8f1804-d38b-4b68-b37d-e2fb5d12d5a0-0",
+   "eventType":"providers/cloud.firestore/eventTypes/document.write",
+   "notSupported":{
+
+   },
+   "params":{
+      "doc":"2Vm2mI1d0wIaK2Waj5to"
+   },
+   "resource":"projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+   "timestamp":"2020-04-23T12:00:27.247187Z"
+}

--- a/test/legacy_events_data/legacy_pubsub.json
+++ b/test/legacy_events_data/legacy_pubsub.json
@@ -1,0 +1,13 @@
+{
+  "eventId": "1215011316659232",
+  "timestamp": "2020-05-18T12:13:19.209Z",
+  "eventType": "providers/cloud.pubsub/eventTypes/topic.publish",
+  "resource": "projects/sample-project/topics/gcf-test",
+  "data": {
+    "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "attributes": {
+      "attribute1": "value1"
+    },
+    "data": "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl"
+  }
+}

--- a/test/legacy_events_data/legacy_storage_change.json
+++ b/test/legacy_events_data/legacy_storage_change.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "bucket": "sample-bucket",
+    "crc32c": "AAAAAA==",
+    "etag": "COu8mb3Dn+kCEAE=",
+    "generation": "1588778055917163",
+    "id": "sample-bucket/MyFile/1588778055917163",
+    "kind": "storage#object",
+    "md5Hash": "ZDQxZDhjZDk4ZjAwYjIwNGU5ODAwOTk4ZWNmODQyN2U=",
+    "mediaLink": "https://www.googleapis.com/download/storage/v1/b/projectid-sample-bucket/o/MyFile?generation=1588778055917163\u0026alt=media",
+    "metageneration": "1",
+    "name": "MyFile",
+    "resourceState": "not_exists",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/projectid-sample-bucket/o/MyFile",
+    "size": "0",
+    "storageClass": "MULTI_REGIONAL",
+    "timeCreated": "2020-05-06T15:14:15.917Z",
+    "timeDeleted": "2020-05-18T09:07:51.799Z",
+    "timeStorageClassUpdated": "2020-05-06T15:14:15.917Z",
+    "updated": "2020-05-06T15:14:15.917Z"
+  },
+  "eventId": "1200401551653202",
+  "eventType": "providers/cloud.storage/eventTypes/object.change",
+  "resource": "projects/_/buckets/sample-bucket/objects/MyFile#1588778055917163",
+  "timestamp": "2020-05-18T09:07:51.799Z"
+}

--- a/test/legacy_events_data/pubsub_binary.json
+++ b/test/legacy_events_data/pubsub_binary.json
@@ -1,0 +1,16 @@
+{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "data": "AQIDBA=="
+   }
+}

--- a/test/legacy_events_data/pubsub_text.json
+++ b/test/legacy_events_data/pubsub_text.json
@@ -1,0 +1,19 @@
+{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+         "attr1":"attr1-value"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+   }
+}

--- a/test/legacy_events_data/storage.json
+++ b/test/legacy_events_data/storage.json
@@ -1,0 +1,31 @@
+{
+   "context": {
+      "eventId": "1147091835525187",
+      "timestamp": "2020-04-23T07:38:57.772Z",
+      "eventType": "google.storage.object.finalize",
+      "resource": {
+         "service": "storage.googleapis.com",
+         "name": "projects/_/buckets/some-bucket/objects/Test.cs",
+         "type": "storage#object"
+      }
+   },
+   "data": {
+      "bucket": "some-bucket",
+      "contentType": "text/plain",
+      "crc32c": "rTVTeQ==",
+      "etag": "CNHZkbuF/ugCEAE=",
+      "generation": "1587627537231057",
+      "id": "some-bucket/Test.cs/1587627537231057",
+      "kind": "storage#object",
+      "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+      "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/Test.cs?generation=1587627537231057\u0026alt=media",
+      "metageneration": "1",
+      "name": "Test.cs",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/Test.cs",
+      "size": "352",
+      "storageClass": "MULTI_REGIONAL",
+      "timeCreated": "2020-04-23T07:38:57.230Z",
+      "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+      "updated": "2020-04-23T07:38:57.230Z"
+   }
+}

--- a/test/test_legacy_events.rb
+++ b/test/test_legacy_events.rb
@@ -1,0 +1,84 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe FunctionsFramework::LegacyEvents do
+  let(:data_dir) { File.join __dir__, "legacy_events_data" }
+
+  def load_legacy_event filename
+    path = File.join data_dir, filename
+    File.open path do |io|
+      env = { "rack.input" => io, "CONTENT_TYPE" => "application/json" }
+      FunctionsFramework::LegacyEvents.decode_rack_env env
+    end
+  end
+
+  it "converts legacy_pubsub.json" do
+    event = load_legacy_event "legacy_pubsub.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", event.source_string
+    assert_equal "google.pubsub.topic.publish.v1", event.type
+    assert_equal "2020-05-18T12:13:19+00:00", event.time.rfc3339
+    assert_equal "value1", event.data["attributes"]["attribute1"]
+  end
+
+  it "converts legacy_storage_change.json" do
+    event = load_legacy_event "legacy_storage_change.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "//storage.googleapis.com/projects/_/buckets/sample-bucket/objects/MyFile#1588778055917163",
+                 event.source_string
+    assert_equal "google.storage.object.change.v1", event.type
+    assert_equal "2020-05-18T09:07:51+00:00", event.time.rfc3339
+    assert_equal "sample-bucket", event.data["bucket"]
+  end
+
+  it "converts pubsub_text.json" do
+    event = load_legacy_event "pubsub_text.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", event.source_string
+    assert_equal "google.pubsub.topic.publish.v1", event.type
+    assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
+    assert_equal "attr1-value", event.data["attributes"]["attr1"]
+  end
+
+  it "converts pubsub_binary.json" do
+    event = load_legacy_event "pubsub_binary.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", event.source_string
+    assert_equal "google.pubsub.topic.publish.v1", event.type
+    assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
+    assert_equal "AQIDBA==", event.data["data"]
+  end
+
+  it "converts storage.json" do
+    event = load_legacy_event "storage.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "//storage.googleapis.com/projects/_/buckets/some-bucket/objects/Test.cs", event.source_string
+    assert_equal "google.storage.object.finalize.v1", event.type
+    assert_equal "2020-04-23T07:38:57+00:00", event.time.rfc3339
+    assert_equal "some-bucket", event.data["bucket"]
+  end
+
+  it "converts firestore_simple.json" do
+    event = load_legacy_event "firestore_simple.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal \
+      "//firestore.googleapis.com/projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+      event.source_string
+    assert_equal "google.firestore.document.write.v1", event.type
+    assert_equal "2020-04-23T12:00:27+00:00", event.time.rfc3339
+    assert_equal "bar", event.data["value"]["fields"]["foo"]["stringValue"]
+  end
+end

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -63,7 +63,7 @@ describe FunctionsFramework::Testing do
       event = FunctionsFramework::Testing.make_cloud_event "Lorem Ipsum"
       assert_instance_of FunctionsFramework::CloudEvents::Event, event
       assert_equal "Lorem Ipsum", event.data
-      assert_match /^random-id/, event.id
+      assert_match %r{^random-id}, event.id
       assert_equal "com.example.test", event.type
       assert_equal "1.0", event.spec_version
       assert_nil event.data_content_type


### PR DESCRIPTION
If a legacy GCF event is sent to an event-receiving function, it is upcasted to a CloudEvent.

In the current implementation, pubsub, storage, and firestore are supported. Test cases were lifted from the [dotnet functions framework repo](https://github.com/GoogleCloudPlatform/functions-framework-dotnet/tree/master/src/Google.Cloud.Functions.Framework.Tests/GcfEvents).