### PR TITLE
fix: Deprecate two-argument event function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Change `app.rb` to read:
 # app.rb
 require "functions_framework"
 
-FunctionsFramework.event("my-handler") do |data, context|
-  FunctionsFramework.logger.info "I received #{data.inspect}"
+FunctionsFramework.cloud_event("my-handler") do |event|
+  FunctionsFramework.logger.info "I received #{event.inspect}"
 end
 ```
 

--- a/examples/echo/app.rb
+++ b/examples/echo/app.rb
@@ -22,6 +22,6 @@ FunctionsFramework.http "http-sample" do |request|
 end
 
 # Create a simple CloudEvents function called "event-sample"
-FunctionsFramework.event "event-sample" do |data, context|
-  FunctionsFramework.logger.info "I received #{data.inspect} in an event of type #{context.type}"
+FunctionsFramework.cloud_event "event-sample" do |event|
+  FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
 end

--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -139,37 +139,10 @@ module FunctionsFramework
     end
 
     ##
-    # Define a function that responds to CloudEvents.
+    # This is an obsolete interface that defines an event function taking two
+    # arguments (data and context) rather than one.
     #
-    # You must provide a name for the function, and a block that implemets the
-    # function. The block should take two arguments: the event _data_ and the
-    # event _context_. Any return value is ignored.
-    #
-    # The event data argument will be one of the following types:
-    #  *  A `String` (with encoding `ASCII-8BIT`) if the data is in the form of
-    #     binary data. You may choose to perform additional interpretation of
-    #     the binary data using information in the content type provided by the
-    #     context argument.
-    #  *  Any data type that can be represented in JSON (i.e. `String`,
-    #     `Integer`, `Array`, `Hash`, `true`, `false`, or `nil`) if the event
-    #     came with a JSON payload. The content type may also be set in the
-    #     context if the data is a String.
-    #
-    # The context argument will be of type {FunctionsFramework::CloudEvents::Event},
-    # and will contain CloudEvents context attributes such as `id` and `type`.
-    #
-    # See also {FunctionsFramework.cloud_event} which defines a function that
-    # takes a single argument of type {FunctionsFramework::CloudEvents::Event}.
-    #
-    # ## Example
-    #
-    #     FunctionsFramework.event "my-function" do |data, context|
-    #       FunctionsFramework.logger.info "Event data: #{data.inspect}"
-    #     end
-    #
-    # @param name [String] The function name. Defaults to {DEFAULT_TARGET}.
-    # @param block [Proc] The function code as a proc.
-    # @return [self]
+    # @deprecated Use {FunctionsFramework.cloud_event} instead.
     #
     def event name = DEFAULT_TARGET, &block
       global_registry.add_event name, &block
@@ -180,11 +153,8 @@ module FunctionsFramework
     # Define a function that responds to CloudEvents.
     #
     # You must provide a name for the function, and a block that implemets the
-    # function. The block should take _one_ argument: the event object of type
+    # function. The block should take one argument: the event object of type
     # {FunctionsFramework::CloudEvents::Event}. Any return value is ignored.
-    #
-    # See also {FunctionsFramework.event} which creates a function that takes
-    # data and context as separate arguments.
     #
     # ## Example
     #

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -54,11 +54,9 @@ module FunctionsFramework
     #
     #  *  A `:http` type function takes a `Rack::Request` argument, and returns
     #     a Rack response type. See {FunctionsFramework::Registry.add_http}.
-    #  *  A `:event` or `:cloud_event` type function takes a
+    #  *  A `:cloud_event` type function takes a
     #     {FunctionsFramework::CloudEvents::Event} argument, and does not
     #     return a value. See {FunctionsFramework::Registry.add_cloud_event}.
-    #     Note that for an `:event` type function, the passed event argument is
-    #     split into two arguments when passed to the underlying block.
     #
     # @param argument [Rack::Request,FunctionsFramework::CloudEvents::Event]
     # @return [Object]

--- a/lib/functions_framework/registry.rb
+++ b/lib/functions_framework/registry.rb
@@ -76,31 +76,10 @@ module FunctionsFramework
     end
 
     ##
-    # Add a CloudEvent function to the registry.
+    # This is an obsolete interface that defines an event function taking two
+    # arguments (data and context) rather than one.
     #
-    # You must provide a name for the function, and a block that implemets the
-    # function. The block should take two arguments: the event _data_ and the
-    # event _context_. Any return value is ignored.
-    #
-    # The event data argument will be one of the following types:
-    #  *  A `String` (with encoding `ASCII-8BIT`) if the data is in the form of
-    #     binary data. You may choose to perform additional interpretation of
-    #     the binary data using information in the content type provided by the
-    #     context argument.
-    #  *  Any data type that can be represented in JSON (i.e. `String`,
-    #     `Integer`, `Array`, `Hash`, `true`, `false`, or `nil`) if the event
-    #     came with a JSON payload. The content type may also be set in the
-    #     context if the data is a String.
-    #
-    # The context argument will be of type {FunctionsFramework::CloudEvents::Event},
-    # and will contain CloudEvents context attributes such as `id` and `type`.
-    #
-    # See also {#add_cloud_event} which creates a function that takes a single
-    # argument of type {FunctionsFramework::CloudEvents::Event}.
-    #
-    # @param name [String] The function name
-    # @param block [Proc] The function code as a proc
-    # @return [self]
+    # @deprecated Use {Registry#add_cloud_event} instead.
     #
     def add_event name, &block
       name = name.to_s
@@ -117,9 +96,6 @@ module FunctionsFramework
     # You must provide a name for the function, and a block that implemets the
     # function. The block should take _one_ argument: the event object of type
     # {FunctionsFramework::CloudEvents::Event}. Any return value is ignored.
-    #
-    # See also {#add_event} which creates a function that takes data and
-    # context as separate arguments.
     #
     # @param name [String] The function name
     # @param block [Proc] The function code as a proc


### PR DESCRIPTION
Closes #10 