### PR TITLE
feat: Add functions-framework-ruby executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ running your "hello" function:
 ```sh
 bundle install
 # ...installs the functions_framework gem and other dependencies
-bundle exec functions-framework --target hello
+bundle exec functions-framework-ruby --target hello
 # ...starts the web server in the foreground
 ```
 
@@ -127,7 +127,7 @@ RUN gem install --no-document bundler \
     && bundle config --local frozen true \
     && bundle install
 
-ENTRYPOINT ["bundle", "exec", "functions-framework"]
+ENTRYPOINT ["bundle", "exec", "functions-framework-ruby"]
 CMD ["--target", "hello"]
 ```
 
@@ -168,7 +168,7 @@ Start up the framework with this new function:
 
 ```sh
 bundle install
-bundle exec functions-framework --target my-handler
+bundle exec functions-framework-ruby --target my-handler
 ```
 
 In a separate shell, you can send a CloudEvent to this function using curl:
@@ -189,7 +189,7 @@ log message from the web server.
 ### Configuring the Functions Framework
 
 The Ruby Functions Framework recognizes the standard command line arguments to
-the `functions-framework` executable. Each argument also corresponds to an
+the `functions-framework-ruby` executable. Each argument also corresponds to an
 environment variable. If you specify both, the environment variable will be
 ignored.
 
@@ -203,12 +203,12 @@ Note: the flag `--signature-type` and corresponding environment variable
 `FUNCTION_SIGNATURE_TYPE` are not used by the Ruby Function Framework, because
 you specify the signature type when defining the function in the source.
 
-The Ruby `functions-framework` executable also recognizes several additional
+The Ruby `functions-framework-ruby` executable also recognizes some additional
 flags that can be used to control logging verbosity, binding, and other
 parameters. For details, see the online help:
 
 ```sh
-functions-framework --help
+functions-framework-ruby --help
 ```
 
 ## For more information

--- a/bin/functions-framework-ruby
+++ b/bin/functions-framework-ruby
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework/cli"
+
+::FunctionsFramework::CLI.new.parse_args(::ARGV).run

--- a/examples/echo/.toys.rb
+++ b/examples/echo/.toys.rb
@@ -83,9 +83,9 @@ tool "server" do
     ::Dir.chdir context_directory
     bin_path =
       if use_release
-        "functions-framework"
+        "functions-framework-ruby"
       else
-        "vendor/functions_framework/bin/functions-framework"
+        "vendor/functions_framework/bin/functions-framework-ruby"
       end
     exec ["bundle", "install"]
     exec ["bundle", "exec", bin_path, "--target", target, "--port", port.to_s, "--detailed-errors"]

--- a/examples/echo/Dockerfile
+++ b/examples/echo/Dockerfile
@@ -7,4 +7,4 @@ RUN gem install --no-document bundler \
     && bundle config --local without "development test" \
     && bundle install
 
-ENTRYPOINT ["bundle", "exec", "functions-framework"]
+ENTRYPOINT ["bundle", "exec", "functions-framework-ruby"]

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -36,7 +36,7 @@ require "functions_framework/version"
                ["LICENSE", ".yardopts"]
   spec.require_paths = ["lib"]
   spec.bindir = "bin"
-  spec.executables = ["functions-framework"]
+  spec.executables = ["functions-framework", "functions-framework-ruby"]
 
   spec.required_ruby_version = ">= 2.4.0"
 

--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -36,8 +36,8 @@ require "functions_framework/version"
 # functions framework. Use the {FunctionsFramework.http},
 # {FunctionsFramework.event}, or {FunctionsFramework.cloud_event} methods to
 # define functions. To serve functions via a web service, invoke the
-# `functions-framework` executable, or use the {FunctionsFramework.start} or
-# {FunctionsFramework.run} methods.
+# `functions-framework-ruby` executable, or use the {FunctionsFramework.start}
+# or {FunctionsFramework.run} methods.
 #
 # ## Internal modules
 #
@@ -48,7 +48,7 @@ require "functions_framework/version"
 #     you define an event function, you will receive the event as a
 #     {FunctionsFramework::CloudEvents::Event} object.
 #  *  {FunctionsFramework::CLI} is the implementation of the
-#     `functions-framework` executable. Most apps will not need to interact
+#     `functions-framework-ruby` executable. Most apps will not need to interact
 #     with this class directly.
 #  *  {FunctionsFramework::Function} is the internal representation of a
 #     function, indicating the type of function (http or cloud event), the
@@ -62,7 +62,7 @@ require "functions_framework/version"
 #  *  {FunctionsFramework::Server} is a web server that makes a function
 #     available via HTTP. It wraps the Puma web server and runs a specific
 #     {FunctionsFramework::Function}. Many apps can simply run the
-#     `functions-framework` executable to spin up a server. However, if you
+#     `functions-framework-ruby` executable to spin up a server. However, if you
 #     need closer control over your execution environment, you can use the
 #     {FunctionsFramework::Server} class to run a server. Note that, in most
 #     cases, it is easier to use the {FunctionsFramework.start} or

--- a/lib/functions_framework/cli.rb
+++ b/lib/functions_framework/cli.rb
@@ -18,7 +18,7 @@ require "functions_framework"
 
 module FunctionsFramework
   ##
-  # Implementation of the functions-framework executable.
+  # Implementation of the functions-framework-ruby executable.
   #
   class CLI
     ##


### PR DESCRIPTION
After the discussion in #9, I think we should provide an unambiguous `functions-framework-ruby` executable (as well as the current `functions-framework`). So that we have it, in case the issue does turn out to be more serious. This PR retains the current `functions-framework` executable but also provides the same executable under the `functions-framework-ruby` name, _and_ documents that as the preferred executable name.