### PR TITLE
fix: Cache definitions loaded using Testing.load_temporary

### DIFF
--- a/test/function_definitions/simple_event.rb
+++ b/test/function_definitions/simple_event.rb
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+
+# Create a simple CloudEvents function called "event-sample"
+FunctionsFramework.cloud_event "simple-event" do |event|
+  FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
+end

--- a/test/function_definitions/simple_http.rb
+++ b/test/function_definitions/simple_http.rb
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+
+# Create a simple HTTP function called "http-sample"
+FunctionsFramework.http "simple-http" do |request|
+  message = "I received a request: #{request.request_method} #{request.url}"
+  request.logger.info message
+  message
+end


### PR DESCRIPTION
Previously, `FunctionsFramework::Testing.load_temporary` would reload all the function definitions each time it is called, even if called with the same file. This could cause redefinition warnings or errors if the file defined non-function things like methods, classes, or constants. Now, we cache the definitions and just apply the cache if the same file is loaded using load_temporary. This probably also gives us a performance benefit in large tests.

Also implement more test cases for the test framework.