### PR TITLE
Support batch events in the server

### DIFF
--- a/lib/functions_framework/cloud_events.rb
+++ b/lib/functions_framework/cloud_events.rb
@@ -74,10 +74,8 @@ module FunctionsFramework
       # the request.
       #
       # @param env [Hash] The Rack environment
-      # @return [FunctionsFramework::CloudEvents::Event] if the request
-      #     includes a single structured or binary event
-      # @return [Array<FunctionsFramework::CloudEvents::Event>] if the request
-      #     includes a batch of structured events
+      # @return [Array<FunctionsFramework::CloudEvents::Event>] of one
+      #     or more events.
       # @return [nil] if the request is not a CloudEvent.
       #
       def decode_rack_env env
@@ -103,13 +101,13 @@ module FunctionsFramework
       # @param input [IO] An IO-like object providing the content
       # @param content_type [FunctionsFramework::CloudEvents::ContentType] the
       #     content type
-      # @return [FunctionsFramework::CloudEvents::Event]
+      # @return [Array<FunctionsFramework::CloudEvents::Event>]
       #
       def decode_structured_content input, content_type
         handlers = @structured_formats[content_type.subtype_format] || []
         handlers.reverse_each do |handler|
           event = handler.decode_structured_content input, content_type
-          return event if event
+          return [event] if event
         end
         raise "Unknown cloudevents format: #{content_type.subtype_format.inspect}"
       end

--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -409,7 +409,7 @@ module FunctionsFramework
       def call env
         return notfound_response if blacklisted_path? env
         logger = env["rack.logger"] = @config.logger
-        event =
+        events =
           begin
             CloudEvents.decode_rack_env(env) ||
               LegacyEvents.decode_rack_env(env) ||
@@ -418,10 +418,12 @@ module FunctionsFramework
             e
           end
         response =
-          if event.is_a? CloudEvents::Event
-            logger.info "FunctionsFramework: Handling CloudEvent"
+          if events.is_a? Array
             begin
-              @function.call event
+              events.each do |event|
+                logger.info "FunctionsFramework: Handling CloudEvent"
+                @function.call event
+              end
               "ok"
             rescue ::StandardError => e
               logger.warn e

--- a/test/test_cloud_events.rb
+++ b/test/test_cloud_events.rb
@@ -49,7 +49,8 @@ describe FunctionsFramework::CloudEvents do
       "rack.input" => StringIO.new(my_json_struct_encoded),
       "CONTENT_TYPE" => "application/cloudevents+json"
     }
-    event = FunctionsFramework::CloudEvents.decode_rack_env env
+    events = FunctionsFramework::CloudEvents.decode_rack_env env
+    event = events[0]
     assert_equal my_id, event.id
     assert_equal my_source, event.source
     assert_equal my_type, event.type


### PR DESCRIPTION
Right now the server doesn't call functions on a batch of `CloudEvent`s due to the type check here: https://github.com/GoogleCloudPlatform/functions-framework-ruby/blob/master/lib/functions_framework/server.rb#L421

My stab at the fix: always return an array when parsing.

There are currently no `server.rb` tests for CloudEvent handlers but let me know if you'd like me to add some. Thanks for your work! 💕 