### PR TITLE
feat: Accept --signature-type on the command line

### DIFF
--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -176,22 +176,19 @@ module FunctionsFramework
     # Start the functions framework server in the background. The server will
     # look up the given target function name in the global registry.
     #
-    # @param target [String] The name of the function to run
-    # @param assert_signature_type ["http","cloudevent",nil] Optional. If
-    #     present, asserts that the given target has the given signature type,
-    #     and raises ArgumentError if the type doesn't match.
+    # @param target [FunctionsFramework::Function,String] The function to run,
+    #     or the name of the function to look up in the global registry.
     # @yield [FunctionsFramework::Server::Config] A config object that can be
     #     manipulated to configure the server.
     # @return [FunctionsFramework::Server]
     #
-    def start target, assert_signature_type: nil, &block
+    def start target, &block
       require "functions_framework/server"
-      function = global_registry[target]
-      raise ::ArgumentError, "Undefined function: #{target.inspect}" if function.nil?
-      unless assert_signature_type.nil? ||
-             assert_signature_type == "http" && function.type == :http ||
-             assert_signature_type == "cloudevent" && function.type == :cloud_event
-        raise ::ArgumentError, "Function #{target.inspect} does not match type #{assert_signature_type}"
+      if target.is_a? ::FunctionsFramework::Function
+        function = target
+      else
+        function = global_registry[target]
+        raise ::ArgumentError, "Undefined function: #{target.inspect}" if function.nil?
       end
       server = Server.new function, &block
       server.respond_to_signals
@@ -202,7 +199,8 @@ module FunctionsFramework
     # Run the functions framework server and block until it stops. The server
     # will look up the given target function name in the global registry.
     #
-    # @param target [String] The name of the function to run
+    # @param target [FunctionsFramework::Function,String] The function to run,
+    #     or the name of the function to look up in the global registry.
     # @yield [FunctionsFramework::Server::Config] A config object that can be
     #     manipulated to configure the server.
     # @return [self]

--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -177,14 +177,22 @@ module FunctionsFramework
     # look up the given target function name in the global registry.
     #
     # @param target [String] The name of the function to run
+    # @param assert_signature_type ["http","cloudevent",nil] Optional. If
+    #     present, asserts that the given target has the given signature type,
+    #     and raises ArgumentError if the type doesn't match.
     # @yield [FunctionsFramework::Server::Config] A config object that can be
     #     manipulated to configure the server.
     # @return [FunctionsFramework::Server]
     #
-    def start target, &block
+    def start target, assert_signature_type: nil, &block
       require "functions_framework/server"
       function = global_registry[target]
       raise ::ArgumentError, "Undefined function: #{target.inspect}" if function.nil?
+      unless assert_signature_type.nil? ||
+             assert_signature_type == "http" && function.type == :http ||
+             assert_signature_type == "cloudevent" && function.type == :cloud_event
+        raise ::ArgumentError, "Function #{target.inspect} does not match type #{assert_signature_type}"
+      end
       server = Server.new function, &block
       server.respond_to_signals
       server.start

--- a/lib/functions_framework/cli.rb
+++ b/lib/functions_framework/cli.rb
@@ -34,7 +34,6 @@ module FunctionsFramework
       @max_threads = nil
       @detailed_errors = nil
       @signature_type = ::ENV["FUNCTION_SIGNATURE_TYPE"]
-      @server = nil
     end
 
     ##

--- a/lib/functions_framework/cli.rb
+++ b/lib/functions_framework/cli.rb
@@ -93,7 +93,9 @@ module FunctionsFramework
     end
 
     ##
-    # Run the configured server.
+    # Run the configured server, and block until it stops.
+    # If a validation error occurs, print a message and exit.
+    #
     # @return [self]
     #
     def run
@@ -106,7 +108,15 @@ module FunctionsFramework
       self
     end
 
-    ## @private
+    ##
+    # Start the configured server and return the running server object.
+    # If a validation error occurs, raise an exception.
+    # This is used for testing the CLI.
+    #
+    # @return [FunctionsFramework::Server]
+    #
+    # @private
+    #
     def start_server
       ::ENV["FUNCTION_TARGET"] = @target
       ::ENV["FUNCTION_SOURCE"] = @source
@@ -132,6 +142,10 @@ module FunctionsFramework
 
     private
 
+    ##
+    # Print the given error message and exit.
+    # @param message [String]
+    #
     def error message
       warn message
       exit 1

--- a/lib/functions_framework/cli.rb
+++ b/lib/functions_framework/cli.rb
@@ -33,6 +33,7 @@ module FunctionsFramework
       @min_threads = nil
       @max_threads = nil
       @detailed_errors = nil
+      @signature_type = ::ENV["FUNCTION_SIGNATURE_TYPE"]
     end
 
     ##
@@ -51,6 +52,11 @@ module FunctionsFramework
         op.on "-s", "--source SOURCE",
               "Set the source file to load (defaults to #{DEFAULT_SOURCE})" do |val|
           @source = val
+        end
+        op.on "--signature-type",
+              "Asserts that the function has the given signature type." \
+              " Supported values are 'http' and 'cloudevent'." do |val|
+          @signature_type = val
         end
         op.on "-p", "--port PORT", "Set the port to listen to (defaults to 8080)" do |val|
           @port = val.to_i
@@ -98,7 +104,7 @@ module FunctionsFramework
       FunctionsFramework.logger.info \
         "FunctionsFramework: Loading functions from #{@source.inspect}..."
       load @source
-      server = ::FunctionsFramework.start @target do |config|
+      server = ::FunctionsFramework.start @target, assert_signature_type: @signature_type do |config|
         config.rack_env = @env
         config.port = @port
         config.bind_addr = @bind

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -24,6 +24,7 @@ describe FunctionsFramework::CLI do
   let(:event_source) { File.join __dir__, "function_definitions", "simple_event.rb" }
   let(:retry_count) { 10 }
   let(:retry_interval) { 0.5 }
+  let(:port) { "8066" }
 
   def run_with_retry cli
     server = cli.start_server
@@ -57,7 +58,6 @@ describe FunctionsFramework::CLI do
   end
 
   it "runs an http server" do
-    port = "9901"
     args = [
       "--source", http_source,
       "--target", "simple-http",
@@ -73,7 +73,6 @@ describe FunctionsFramework::CLI do
   end
 
   it "succeeds the signature type check for an http server" do
-    port = "9902"
     args = [
       "--source", http_source,
       "--target", "simple-http",
@@ -87,7 +86,6 @@ describe FunctionsFramework::CLI do
   end
 
   it "fails the signature type check for an http server" do
-    port = "9903"
     args = [
       "--source", http_source,
       "--target", "simple-http",
@@ -104,7 +102,6 @@ describe FunctionsFramework::CLI do
   end
 
   it "succeeds the signature type check for an event server" do
-    port = "9904"
     args = [
       "--source", event_source,
       "--target", "simple-event",
@@ -118,7 +115,6 @@ describe FunctionsFramework::CLI do
   end
 
   it "fails the signature type check for an event server" do
-    port = "9905"
     args = [
       "--source", event_source,
       "--target", "simple-event",

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,0 +1,136 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+require "net/http"
+require "uri"
+
+require "functions_framework/cli"
+
+describe FunctionsFramework::CLI do
+  let(:http_source) { File.join __dir__, "function_definitions", "simple_http.rb" }
+  let(:event_source) { File.join __dir__, "function_definitions", "simple_event.rb" }
+  let(:retry_count) { 10 }
+  let(:retry_interval) { 0.5 }
+
+  def run_with_retry cli
+    server = cli.start_server
+    begin
+      last_error = nil
+      retry_count.times do
+        begin
+          return yield
+        rescue ::SystemCallError => e
+          last_error = e
+        end
+      end
+      raise last_error
+    ensure
+      server.stop.wait_until_stopped timeout: 10
+    end
+  end
+
+  before do
+    @saved_registry = FunctionsFramework.global_registry
+    FunctionsFramework.global_registry = FunctionsFramework::Registry.new
+    @saved_level = FunctionsFramework.logger.level
+  end
+
+  after do
+    FunctionsFramework.global_registry = @saved_registry
+    FunctionsFramework.logger.level = @saved_level
+    ENV["FUNCTION_TARGET"] = nil
+    ENV["FUNCTION_SOURCE"] = nil
+    ENV["FUNCTION_SIGNATURE_TYPE"] = nil
+  end
+
+  it "runs an http server" do
+    port = "9901"
+    args = [
+      "--source", http_source,
+      "--target", "simple-http",
+      "--port", port,
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    response = run_with_retry cli do
+      Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
+    end
+    assert_equal "200", response.code
+    assert_equal "I received a request: GET http://127.0.0.1:#{port}/", response.body
+  end
+
+  it "succeeds the signature type check for an http server" do
+    port = "9902"
+    args = [
+      "--source", http_source,
+      "--target", "simple-http",
+      "--port", port,
+      "--signature-type", "http",
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    run_with_retry cli do
+    end
+  end
+
+  it "fails the signature type check for an http server" do
+    port = "9903"
+    args = [
+      "--source", http_source,
+      "--target", "simple-http",
+      "--port", port,
+      "--signature-type", "cloudevent",
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    error = assert_raises(RuntimeError) do
+      run_with_retry cli do
+      end
+    end
+    assert_match(/Function "simple-http" does not match type cloudevent/, error.message)
+  end
+
+  it "succeeds the signature type check for an event server" do
+    port = "9904"
+    args = [
+      "--source", event_source,
+      "--target", "simple-event",
+      "--port", port,
+      "--signature-type", "cloudevent",
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    run_with_retry cli do
+    end
+  end
+
+  it "fails the signature type check for an event server" do
+    port = "9905"
+    args = [
+      "--source", event_source,
+      "--target", "simple-event",
+      "--port", port,
+      "--signature-type", "http",
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    error = assert_raises(RuntimeError) do
+      run_with_retry cli do
+      end
+    end
+    assert_match(/Function "simple-event" does not match type http/, error.message)
+  end
+end


### PR DESCRIPTION
This _allows_ the `--signature-type` flag to be passed to Ruby's functions framework executable. Technically, this is not needed because Ruby's function definition syntax makes the signature type explicit. However, I wasn't clear from my reading of the [FF spec](https://github.com/GoogleCloudPlatform/functions-framework) whether:
* the framework _must_ accept a `--signature-type` flag (even if it is not strictly necessary)?
* any signature type provided (either by `--signature-type` flag, or `FUNCTION_SIGNATURE_TYPE` environment variable), _must_ be respected?

@grant ^

If it turns out that either of the above is true, then this PR provides an implementation for Ruby. It _optionally_ accepts both input options (the environment variable and command-line flag), and if a signature type is provided, the framework checks it against the specified function and raises an error if it does not match. If, however, both above are not necessary, we can throw away this PR.