### PR TITLE
fix: Rename echo sample functions to conform to GCF restrictions

### DIFF
--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -9,8 +9,8 @@ or by the current local source of the Functions Framework.
 
 ## About the examples
 
-There are two example functions, an HTTP function called `http_sample` and a
-CloudEvents function called `event_sample`.
+There are two example functions, an HTTP function called `http_example` and a
+CloudEvents function called `event_example`.
 
 The HTTP function generates a simple message saying it received the request.
 It logs this message, and sends it as the response body.
@@ -52,12 +52,12 @@ toys test
 ### Running the examples locally
 
 To perform integration tests of the functions, start the server in a shell, and
-pass the name of the function to run (either `http_sample` or `event_sample`).
+pass the name of the function to run (either `http_example` or `event_example`).
 
 Here is how to serve the HTTP sample function:
 
 ```sh
-toys server http_sample
+toys server http_example
 ```
 
 Then, in a separate shell, you can send requests to it:
@@ -69,7 +69,7 @@ toys request
 To serve the event sample function:
 
 ```sh
-toys server event_sample
+toys server event_example
 ```
 
 Then, in a separate shell, you can send events to it:
@@ -95,7 +95,7 @@ Then you can run it in Docker by passing the function name to
 `toys image server`, as below:
 
 ```sh
-toys image server http_sample
+toys image server http_example
 ```
 
 Again, use `toys request` or `toys event` to send example requests.
@@ -107,7 +107,7 @@ To deploy to Cloud Run, first create a project and enable billing. Then run the
 example:
 
 ```sh
-toys run deploy http_sample --project=[PROJECT NAME] 
+toys run deploy http_example --project=[PROJECT NAME] 
 ```
 
 It may ask you for permission to enable the Cloud Build and Cloud Run APIs for

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -9,8 +9,8 @@ or by the current local source of the Functions Framework.
 
 ## About the examples
 
-There are two example functions, an HTTP function called `http-sample` and a
-CloudEvents function called `event-sample`.
+There are two example functions, an HTTP function called `http_sample` and a
+CloudEvents function called `event_sample`.
 
 The HTTP function generates a simple message saying it received the request.
 It logs this message, and sends it as the response body.
@@ -52,12 +52,12 @@ toys test
 ### Running the examples locally
 
 To perform integration tests of the functions, start the server in a shell, and
-pass the name of the function to run (either `http-sample` or `event-sample`).
+pass the name of the function to run (either `http_sample` or `event_sample`).
 
 Here is how to serve the HTTP sample function:
 
 ```sh
-toys server http-sample
+toys server http_sample
 ```
 
 Then, in a separate shell, you can send requests to it:
@@ -69,7 +69,7 @@ toys request
 To serve the event sample function:
 
 ```sh
-toys server event-sample
+toys server event_sample
 ```
 
 Then, in a separate shell, you can send events to it:
@@ -95,7 +95,7 @@ Then you can run it in Docker by passing the function name to
 `toys image server`, as below:
 
 ```sh
-toys image server http-sample
+toys image server http_sample
 ```
 
 Again, use `toys request` or `toys event` to send example requests.
@@ -107,7 +107,7 @@ To deploy to Cloud Run, first create a project and enable billing. Then run the
 example:
 
 ```sh
-toys run deploy http-sample --project=[PROJECT NAME] 
+toys run deploy http_sample --project=[PROJECT NAME] 
 ```
 
 It may ask you for permission to enable the Cloud Build and Cloud Run APIs for

--- a/examples/echo/app.rb
+++ b/examples/echo/app.rb
@@ -14,14 +14,14 @@
 
 require "functions_framework"
 
-# Create a simple HTTP function called "http_sample"
-FunctionsFramework.http "http_sample" do |request|
+# Create a simple HTTP function called "http_example"
+FunctionsFramework.http "http_example" do |request|
   message = "I received a request: #{request.request_method} #{request.url}"
   request.logger.info message
   message
 end
 
-# Create a simple CloudEvents function called "event_sample"
-FunctionsFramework.cloud_event "event_sample" do |event|
+# Create a simple CloudEvents function called "event_example"
+FunctionsFramework.cloud_event "event_example" do |event|
   FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
 end

--- a/examples/echo/app.rb
+++ b/examples/echo/app.rb
@@ -14,14 +14,14 @@
 
 require "functions_framework"
 
-# Create a simple HTTP function called "http-sample"
-FunctionsFramework.http "http-sample" do |request|
+# Create a simple HTTP function called "http_sample"
+FunctionsFramework.http "http_sample" do |request|
   message = "I received a request: #{request.request_method} #{request.url}"
   request.logger.info message
   message
 end
 
-# Create a simple CloudEvents function called "event-sample"
-FunctionsFramework.cloud_event "event-sample" do |event|
+# Create a simple CloudEvents function called "event_sample"
+FunctionsFramework.cloud_event "event_sample" do |event|
   FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
 end

--- a/examples/echo/test/test_app.rb
+++ b/examples/echo/test/test_app.rb
@@ -16,7 +16,7 @@ require "minitest/autorun"
 
 require "functions_framework/testing"
 
-describe "http-sample function" do
+describe "http_sample function" do
   include FunctionsFramework::Testing
 
   it "generates the correct response body" do
@@ -24,7 +24,7 @@ describe "http-sample function" do
       request = make_get_request "http://example.com:8080/"
       response = nil
       _out, err = capture_subprocess_io do
-        response = call_http "http-sample", request
+        response = call_http "http_sample", request
       end
       assert_equal 200, response.status
       assert_equal "I received a request: GET http://example.com:8080/", response.body.join
@@ -33,14 +33,14 @@ describe "http-sample function" do
   end
 end
 
-describe "event-sample function" do
+describe "event_sample function" do
   include FunctionsFramework::Testing
 
   it "outputs the expected log" do
     load_temporary "app.rb" do
       event = make_cloud_event "Hello, world!"
       _out, err = capture_subprocess_io do
-        call_event "event-sample", event
+        call_event "event_sample", event
       end
       assert_match %r{I received "Hello, world!" in an event of type com\.example\.test}, err
     end

--- a/examples/echo/test/test_app.rb
+++ b/examples/echo/test/test_app.rb
@@ -16,7 +16,7 @@ require "minitest/autorun"
 
 require "functions_framework/testing"
 
-describe "http_sample function" do
+describe "http_example function" do
   include FunctionsFramework::Testing
 
   it "generates the correct response body" do
@@ -24,7 +24,7 @@ describe "http_sample function" do
       request = make_get_request "http://example.com:8080/"
       response = nil
       _out, err = capture_subprocess_io do
-        response = call_http "http_sample", request
+        response = call_http "http_example", request
       end
       assert_equal 200, response.status
       assert_equal "I received a request: GET http://example.com:8080/", response.body.join
@@ -33,14 +33,14 @@ describe "http_sample function" do
   end
 end
 
-describe "event_sample function" do
+describe "event_example function" do
   include FunctionsFramework::Testing
 
   it "outputs the expected log" do
     load_temporary "app.rb" do
       event = make_cloud_event "Hello, world!"
       _out, err = capture_subprocess_io do
-        call_event "event_sample", event
+        call_event "event_example", event
       end
       assert_match %r{I received "Hello, world!" in an event of type com\.example\.test}, err
     end


### PR DESCRIPTION
The sample functions were named `http-sample` and `event-sample` but hyphens are not allowed by GCF. Changed to underscores.