### PR TITLE
fix: Update pubsub CloudEvent data conversion to match Cloud Run

### DIFF
--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -84,12 +84,13 @@ module FunctionsFramework
       source, subject = convert_source context[:service], context[:resource]
       type = LEGACY_TYPE_TO_CE_TYPE[context[:type]]
       return nil unless type && source
+      ce_data = convert_data context[:service], data
       CloudEvents::Event.new id:                context[:id],
                              source:            source,
                              type:              type,
                              spec_version:      "1.0",
                              data_content_type: "application/json",
-                             data:              data,
+                             data:              ce_data,
                              subject:           subject,
                              time:              context[:timestamp]
     end
@@ -101,6 +102,14 @@ module FunctionsFramework
         ["//#{service}/#{match[1]}", match[2]]
       else
         ["//#{service}/#{resource}", nil]
+      end
+    end
+
+    def convert_data service, data
+      if service == "pubsub.googleapis.com"
+        { "message" => data, "subscription" => nil }
+      else
+        data
       end
     end
 

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -34,7 +34,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "google.cloud.pubsub.topic.v1.messagePublished", event.type
     assert_nil event.subject
     assert_equal "2020-05-18T12:13:19+00:00", event.time.rfc3339
-    assert_equal "value1", event.data["attributes"]["attribute1"]
+    assert_equal "value1", event.data["message"]["attributes"]["attribute1"]
+    assert_equal "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl", event.data["message"]["data"]
+    assert event.data.key? "subscription" # Exists but not yet set.
+    assert_nil event.data["subscription"]
   end
 
   it "converts legacy_storage_change.json" do
@@ -56,7 +59,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "google.cloud.pubsub.topic.v1.messagePublished", event.type
     assert_nil event.subject
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
-    assert_equal "attr1-value", event.data["attributes"]["attr1"]
+    assert_equal "attr1-value", event.data["message"]["attributes"]["attr1"]
+    assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
+    assert event.data.key? "subscription" # Exists but not yet set.
+    assert_nil event.data["subscription"]
   end
 
   it "converts pubsub_binary.json" do
@@ -67,7 +73,9 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "google.cloud.pubsub.topic.v1.messagePublished", event.type
     assert_nil event.subject
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
-    assert_equal "AQIDBA==", event.data["data"]
+    assert_equal "AQIDBA==", event.data["message"]["data"]
+    assert event.data.key? "subscription" # Exists but not yet set.
+    assert_nil event.data["subscription"]
   end
 
   it "converts storage.json" do


### PR DESCRIPTION
@jskeet identified a difference in how PubSub event data is presented in Cloud Run. It was decided that functions frameworks would adjust their legacy event to CloudEvent conversion logic to match.