### PR TITLE
docs: Change curl to use http instead of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bundle exec functions-framework-ruby --target hello
 In a separate shell, you can send requests to this function using curl:
 
 ```sh
-curl https://localhost:8080
+curl http://localhost:8080
 # Output: Hello, world!
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -92,7 +92,7 @@ bundle exec functions-framework-ruby --target hello
 In a separate shell, you can send requests to this function using curl:
 
 ```sh
-curl https://localhost:8080
+curl http://localhost:8080
 # Output: Hello, world!
 ```
 


### PR DESCRIPTION
Change the command line to test the start the sample with curl to use http instead of https as that's what the framework accepts.