### PR TITLE
fix: Allow return statements in functions

### DIFF
--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -30,7 +30,7 @@ module FunctionsFramework
     def initialize name, type, &block
       @name = name
       @type = type
-      @block = block
+      @callable = lambda(&block)
     end
 
     ##
@@ -44,9 +44,9 @@ module FunctionsFramework
     attr_reader :type
 
     ##
-    # @return [Proc] The function code as a proc
+    # @return [Proc] The function code as a lambda Proc
     #
-    attr_reader :block
+    attr_reader :callable
 
     ##
     # Call the function. You must pass an argument appropriate to the type
@@ -64,9 +64,9 @@ module FunctionsFramework
     def call argument
       case type
       when :event
-        block.call argument.data, argument
+        callable.call argument.data, argument
       else
-        block.call argument
+        callable.call argument
       end
     end
   end

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -30,7 +30,8 @@ module FunctionsFramework
     def initialize name, type, &block
       @name = name
       @type = type
-      @callable = lambda(&block)
+      @execution_context_class = Class.new
+      @execution_context_class.define_method :call, &block
     end
 
     ##
@@ -42,11 +43,6 @@ module FunctionsFramework
     # @return [Symbol] The function type
     #
     attr_reader :type
-
-    ##
-    # @return [Proc] The function code as a lambda Proc
-    #
-    attr_reader :callable
 
     ##
     # Call the function. You must pass an argument appropriate to the type
@@ -62,11 +58,12 @@ module FunctionsFramework
     # @return [Object]
     #
     def call argument
+      execution_context = @execution_context_class.new
       case type
       when :event
-        callable.call argument.data, argument
+        execution_context.call argument.data, argument
       else
-        callable.call argument
+        execution_context.call argument
       end
     end
   end

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -30,8 +30,9 @@ module FunctionsFramework
     def initialize name, type, &block
       @name = name
       @type = type
-      @execution_context_class = Class.new
-      @execution_context_class.define_method :call, &block
+      @execution_context_class = Class.new do
+        define_method :call, &block
+      end
     end
 
     ##

--- a/test/function_definitions/return_http.rb
+++ b/test/function_definitions/return_http.rb
@@ -14,9 +14,8 @@
 
 require "functions_framework"
 
-# Create a simple HTTP function called "simple_http"
-FunctionsFramework.http "simple_http" do |request|
-  message = "I received a request: #{request.request_method} #{request.url}"
-  request.logger.info message
-  message
+# Create an http function that uses return
+FunctionsFramework.http "return_http" do |request|
+  return "I received a GET request: #{request.url}" if request.request_method == "GET"
+  "I received a #{request.request_method} request."
 end

--- a/test/function_definitions/simple_event.rb
+++ b/test/function_definitions/simple_event.rb
@@ -14,7 +14,7 @@
 
 require "functions_framework"
 
-# Create a simple CloudEvents function called "event-sample"
-FunctionsFramework.cloud_event "simple-event" do |event|
+# Create a simple CloudEvents function called "simple_event"
+FunctionsFramework.cloud_event "simple_event" do |event|
   FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -22,6 +22,7 @@ require "functions_framework/cli"
 describe FunctionsFramework::CLI do
   let(:http_source) { File.join __dir__, "function_definitions", "simple_http.rb" }
   let(:event_source) { File.join __dir__, "function_definitions", "simple_event.rb" }
+  let(:http_return_source) { File.join __dir__, "function_definitions", "return_http.rb" }
   let(:retry_count) { 10 }
   let(:retry_interval) { 0.5 }
   let(:port) { "8066" }
@@ -60,7 +61,7 @@ describe FunctionsFramework::CLI do
   it "runs an http server" do
     args = [
       "--source", http_source,
-      "--target", "simple-http",
+      "--target", "simple_http",
       "--port", port,
       "-q"
     ]
@@ -72,10 +73,25 @@ describe FunctionsFramework::CLI do
     assert_equal "I received a request: GET http://127.0.0.1:#{port}/", response.body
   end
 
+  it "runs an http server with a function that includes a return" do
+    args = [
+      "--source", http_return_source,
+      "--target", "return_http",
+      "--port", port,
+      "-q"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    response = run_with_retry cli do
+      Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
+    end
+    assert_equal "200", response.code
+    assert_equal "I received a GET request: http://127.0.0.1:#{port}/", response.body
+  end
+
   it "succeeds the signature type check for an http server" do
     args = [
       "--source", http_source,
-      "--target", "simple-http",
+      "--target", "simple_http",
       "--port", port,
       "--signature-type", "http",
       "-q"
@@ -88,7 +104,7 @@ describe FunctionsFramework::CLI do
   it "fails the signature type check for an http server" do
     args = [
       "--source", http_source,
-      "--target", "simple-http",
+      "--target", "simple_http",
       "--port", port,
       "--signature-type", "cloudevent",
       "-q"
@@ -98,13 +114,13 @@ describe FunctionsFramework::CLI do
       run_with_retry cli do
       end
     end
-    assert_match(/Function "simple-http" does not match type cloudevent/, error.message)
+    assert_match(/Function "simple_http" does not match type cloudevent/, error.message)
   end
 
   it "succeeds the signature type check for an event server" do
     args = [
       "--source", event_source,
-      "--target", "simple-event",
+      "--target", "simple_event",
       "--port", port,
       "--signature-type", "cloudevent",
       "-q"
@@ -117,7 +133,7 @@ describe FunctionsFramework::CLI do
   it "succeeds the signature type check for a legacy event server" do
     args = [
       "--source", event_source,
-      "--target", "simple-event",
+      "--target", "simple_event",
       "--port", port,
       "--signature-type", "event",
       "-q"
@@ -130,7 +146,7 @@ describe FunctionsFramework::CLI do
   it "fails the signature type check for an event server" do
     args = [
       "--source", event_source,
-      "--target", "simple-event",
+      "--target", "simple_event",
       "--port", port,
       "--signature-type", "http",
       "-q"
@@ -140,6 +156,6 @@ describe FunctionsFramework::CLI do
       run_with_retry cli do
       end
     end
-    assert_match(/Function "simple-event" does not match type http/, error.message)
+    assert_match(/Function "simple_event" does not match type http/, error.message)
   end
 end

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -17,34 +17,45 @@ require "ostruct"
 
 describe FunctionsFramework::Function do
   it "represents an http function" do
-    function = FunctionsFramework::Function.new "my-func", :http do |request|
+    function = FunctionsFramework::Function.new "my_func", :http do |request|
       assert_equal "the-request", request
       "hello"
     end
-    assert_equal "my-func", function.name
+    assert_equal "my_func", function.name
+    assert_equal :http, function.type
+    response = function.call "the-request"
+    assert_equal "hello", response
+  end
+
+  it "represents an http function with a return statement" do
+    function = FunctionsFramework::Function.new "my_func", :http do |request|
+      return "hello" if request == "the-request"
+      "goodbye"
+    end
+    assert_equal "my_func", function.name
     assert_equal :http, function.type
     response = function.call "the-request"
     assert_equal "hello", response
   end
 
   it "defines an event function" do
-    function = FunctionsFramework::Function.new "my-func", :event do |data, context|
+    function = FunctionsFramework::Function.new "my_func", :event do |data, context|
       assert_equal "the-data", data
       assert_equal "the-id", context.id
       "ok"
     end
-    assert_equal "my-func", function.name
+    assert_equal "my_func", function.name
     assert_equal :event, function.type
     event = OpenStruct.new data: "the-data", id: "the-id"
     function.call event
   end
 
   it "defines a cloud_event function" do
-    function = FunctionsFramework::Function.new "my-func", :cloud_event do |event|
+    function = FunctionsFramework::Function.new "my_func", :cloud_event do |event|
       assert_equal "the-event", event
       "ok"
     end
-    assert_equal "my-func", function.name
+    assert_equal "my_func", function.name
     assert_equal :cloud_event, function.type
     function.call "the-event"
   end

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -17,8 +17,9 @@ require "ostruct"
 
 describe FunctionsFramework::Function do
   it "represents an http function" do
+    tester = self
     function = FunctionsFramework::Function.new "my_func", :http do |request|
-      assert_equal "the-request", request
+      tester.assert_equal "the-request", request
       "hello"
     end
     assert_equal "my_func", function.name
@@ -39,9 +40,10 @@ describe FunctionsFramework::Function do
   end
 
   it "defines an event function" do
+    tester = self
     function = FunctionsFramework::Function.new "my_func", :event do |data, context|
-      assert_equal "the-data", data
-      assert_equal "the-id", context.id
+      tester.assert_equal "the-data", data
+      tester.assert_equal "the-id", context.id
       "ok"
     end
     assert_equal "my_func", function.name
@@ -51,8 +53,9 @@ describe FunctionsFramework::Function do
   end
 
   it "defines a cloud_event function" do
+    tester = self
     function = FunctionsFramework::Function.new "my_func", :cloud_event do |event|
-      assert_equal "the-event", event
+      tester.assert_equal "the-event", event
       "ok"
     end
     assert_equal "my_func", function.name

--- a/test/test_registry.rb
+++ b/test/test_registry.rb
@@ -24,8 +24,9 @@ describe FunctionsFramework::Registry do
   end
 
   it "defines an http function" do
+    tester = self
     registry.add_http "my-func" do |request|
-      assert_equal "the-request", request
+      tester.assert_equal "the-request", request
       "hello"
     end
     assert_equal ["my-func"], registry.names
@@ -37,9 +38,10 @@ describe FunctionsFramework::Registry do
   end
 
   it "defines an event function" do
+    tester = self
     registry.add_event "my-func" do |data, context|
-      assert_equal "the-data", data
-      assert_equal "the-id", context.id
+      tester.assert_equal "the-data", data
+      tester.assert_equal "the-id", context.id
       "ok"
     end
     assert_equal ["my-func"], registry.names
@@ -51,8 +53,9 @@ describe FunctionsFramework::Registry do
   end
 
   it "defines a cloud_event function" do
+    tester = self
     registry.add_cloud_event "my-func" do |event|
-      assert_equal "the-event", event
+      tester.assert_equal "the-event", event
       "ok"
     end
     assert_equal ["my-func"], registry.names


### PR DESCRIPTION
Functions raised `LocalJumpError` if they executed an explicit `return` statement directly in the function block. Fixed by setting the lambda bit on all functions, by recasting them as methods on an anonymous class.

(This also opens the door for future use of that anonymous class as a "context" from which we could potentially get things like per-invocation loggers, the source and target of the running function, etc. Such extensions aren't implemented now, pending design discussion, but they are now possible.)

Also updated test cases to use function names without hyphens.