### PR TITLE
feat: Provide an explicit execution context class

### DIFF
--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -15,6 +15,7 @@
 require "logger"
 
 require "functions_framework/cloud_events"
+require "functions_framework/execution_context"
 require "functions_framework/function"
 require "functions_framework/legacy_event_converter"
 require "functions_framework/registry"
@@ -136,17 +137,6 @@ module FunctionsFramework
     #
     def http name = DEFAULT_TARGET, &block
       global_registry.add_http name, &block
-      self
-    end
-
-    ##
-    # This is an obsolete interface that defines an event function taking two
-    # arguments (data and context) rather than one.
-    #
-    # @deprecated Use {FunctionsFramework.cloud_event} instead.
-    #
-    def event name = DEFAULT_TARGET, &block
-      global_registry.add_event name, &block
       self
     end
 

--- a/lib/functions_framework/execution_context.rb
+++ b/lib/functions_framework/execution_context.rb
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module FunctionsFramework
+  ##
+  # The execution context of a running function.
+  #
+  # An object of this class is `self` while a function block is running.
+  #
+  class ExecutionContext
+    ##
+    # Create an ExecutionContext
+    # @private
+    #
+    def initialize function, logger: nil
+      @function_name = function.name
+      @function_type = function.type
+      @logger = logger || FunctionsFramework.logger
+    end
+
+    ##
+    # @return [::Logger] A logger for use by this function.
+    #
+    attr_reader :logger
+
+    ##
+    # @return [String] The name of the running function.
+    #
+    attr_reader :function_name
+
+    ##
+    # @return [Symbol] The type of the running function. Possible values are
+    #     `:http` and `:cloud_event`.
+    #
+    attr_reader :function_type
+  end
+end

--- a/lib/functions_framework/registry.rb
+++ b/lib/functions_framework/registry.rb
@@ -76,21 +76,6 @@ module FunctionsFramework
     end
 
     ##
-    # This is an obsolete interface that defines an event function taking two
-    # arguments (data and context) rather than one.
-    #
-    # @deprecated Use {Registry#add_cloud_event} instead.
-    #
-    def add_event name, &block
-      name = name.to_s
-      synchronize do
-        raise ::ArgumentError, "Function already defined: #{name}" if @functions.key? name
-        @functions[name] = Function.new name, :event, &block
-      end
-      self
-    end
-
-    ##
     # Add a CloudEvent function to the registry.
     #
     # You must provide a name for the function, and a block that implemets the

--- a/lib/functions_framework/testing.rb
+++ b/lib/functions_framework/testing.rb
@@ -87,7 +87,7 @@ module FunctionsFramework
       function = ::FunctionsFramework.global_registry[name]
       case function&.type
       when :http
-        Testing.interpret_response { function.call request }
+        Testing.interpret_response { function.execution_context.call request }
       when nil
         raise "Unknown function name #{name}"
       else
@@ -97,7 +97,7 @@ module FunctionsFramework
 
     ##
     # Call the given event function for testing. The underlying function must
-    # be of type `:event` or `:cloud_event`.
+    # be of type :cloud_event`.
     #
     # @param name [String] The name of the function to call
     # @param event [FunctionsFramework::CloudEvets::Event] The event to send
@@ -106,8 +106,8 @@ module FunctionsFramework
     def call_event name, event
       function = ::FunctionsFramework.global_registry[name]
       case function&.type
-      when :event, :cloud_event
-        function.call event
+      when :cloud_event
+        function.execution_context.call event
         nil
       when nil
         raise "Unknown function name #{name}"

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -20,11 +20,12 @@ describe FunctionsFramework::Function do
     tester = self
     function = FunctionsFramework::Function.new "my_func", :http do |request|
       tester.assert_equal "the-request", request
+      tester.assert_equal "my_func", function_name
       "hello"
     end
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.call "the-request"
+    response = function.execution_context.call "the-request"
     assert_equal "hello", response
   end
 
@@ -35,31 +36,19 @@ describe FunctionsFramework::Function do
     end
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.call "the-request"
+    response = function.execution_context.call "the-request"
     assert_equal "hello", response
-  end
-
-  it "defines an event function" do
-    tester = self
-    function = FunctionsFramework::Function.new "my_func", :event do |data, context|
-      tester.assert_equal "the-data", data
-      tester.assert_equal "the-id", context.id
-      "ok"
-    end
-    assert_equal "my_func", function.name
-    assert_equal :event, function.type
-    event = OpenStruct.new data: "the-data", id: "the-id"
-    function.call event
   end
 
   it "defines a cloud_event function" do
     tester = self
-    function = FunctionsFramework::Function.new "my_func", :cloud_event do |event|
+    function = FunctionsFramework::Function.new "my_event_func", :cloud_event do |event|
       tester.assert_equal "the-event", event
+      tester.assert_equal "my_event_func", function_name
       "ok"
     end
-    assert_equal "my_func", function.name
+    assert_equal "my_event_func", function.name
     assert_equal :cloud_event, function.type
-    function.call "the-event"
+    function.execution_context.call "the-event"
   end
 end

--- a/test/test_registry.rb
+++ b/test/test_registry.rb
@@ -20,60 +20,45 @@ describe FunctionsFramework::Registry do
 
   it "starts out empty" do
     assert_empty registry.names
-    assert_nil registry["my-func"]
+    assert_nil registry["my_func"]
   end
 
   it "defines an http function" do
     tester = self
-    registry.add_http "my-func" do |request|
+    registry.add_http "my_func" do |request|
       tester.assert_equal "the-request", request
       "hello"
     end
-    assert_equal ["my-func"], registry.names
-    function = registry["my-func"]
-    assert_equal "my-func", function.name
+    assert_equal ["my_func"], registry.names
+    function = registry["my_func"]
+    assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.call "the-request"
+    response = function.execution_context.call "the-request"
     assert_equal "hello", response
-  end
-
-  it "defines an event function" do
-    tester = self
-    registry.add_event "my-func" do |data, context|
-      tester.assert_equal "the-data", data
-      tester.assert_equal "the-id", context.id
-      "ok"
-    end
-    assert_equal ["my-func"], registry.names
-    function = registry["my-func"]
-    assert_equal "my-func", function.name
-    assert_equal :event, function.type
-    event = OpenStruct.new data: "the-data", id: "the-id"
-    function.call event
   end
 
   it "defines a cloud_event function" do
     tester = self
-    registry.add_cloud_event "my-func" do |event|
+    registry.add_cloud_event "my_func" do |event|
       tester.assert_equal "the-event", event
       "ok"
     end
-    assert_equal ["my-func"], registry.names
-    function = registry["my-func"]
-    assert_equal "my-func", function.name
+    assert_equal ["my_func"], registry.names
+    function = registry["my_func"]
+    assert_equal "my_func", function.name
     assert_equal :cloud_event, function.type
-    function.call "the-event"
+    function.execution_context.call "the-event"
   end
 
   it "defines multiple functions" do
     registry.add_http "func2" do |request|
       "hello"
     end
-    registry.add_event "func1" do |data, context|
+    registry.add_cloud_event "func1" do |event|
       "ok"
     end
     assert_equal ["func1", "func2"], registry.names
-    assert_equal :event, registry["func1"].type
+    assert_equal :cloud_event, registry["func1"].type
     assert_equal :http, registry["func2"].type
   end
 end


### PR DESCRIPTION
* The `self` during a function invocation is currently an anonymous class. Provide a base class for that anonymous class (which gives us a place to include some context-related accessors such as the logger.)
* Drop the legacy `:event` function type, which was deprecated and only marginally supported anyway. Now only `:http` and `:cloud_event` types are supported.
