### PR TITLE
fix: Do correct percent-encoding of CloudEvents binary headers

### DIFF
--- a/test/cloud_events/test_http_binding.rb
+++ b/test/cloud_events/test_http_binding.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I finally think I understand the whole percent-encoding part of the CE spec...