### PR TITLE
docs: Update links to reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Functions Framework [![Documentation](https://img.shields.io/badge/docs-FunctionsFramework-red.svg)](https://rubydoc.info/gems/functions_framework/FunctionsFramework) [![Gem Version](https://badge.fury.io/rb/functions_framework.svg)](https://badge.fury.io/rb/functions_framework)
+# Functions Framework [![Documentation](https://img.shields.io/badge/docs-FunctionsFramework-red.svg)](https://googlecloudplatform.github.io/functions-framework-ruby/latest) [![Gem Version](https://badge.fury.io/rb/functions_framework.svg)](https://badge.fury.io/rb/functions_framework)
 
 An open source framework for writing lightweight, portable Ruby functions that
 run in a serverless environment. Functions written to this Framework will run
@@ -98,26 +98,26 @@ Stop the server with `CTRL+C`.
 
 These guides provide additional getting-started information.
 
- *  **[Writing Functions](https://rubydoc.info/gems/functions_framework/file/docs/writing-functions.md)**
+ *  **[Writing Functions](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.writing-functions.html)**
     : How to write functions that respond to HTTP requests, industry-standard
     [CloudEvents](https://cloudevents.io), as well as events sent from Google
     Cloud services such as [Pub/Sub](https://cloud.google.com/pubsub) and
     [Storage](https://cloud.google.com/storage).
- *  **[Testing Functions](https://rubydoc.info/gems/functions_framework/file/docs/testing-functions.md)**
+ *  **[Testing Functions](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.testing-functions.html)**
     : How to use the testing features of the Functions Framework to write local
     unit tests for your functions using standard Ruby testing frameworks such
     as [Minitest](https://github.com/seattlerb/minitest) and
     [RSpec](https://rspec.info/).
- *  **[Running a Functions Server](https://rubydoc.info/gems/functions_framework/file/docs/running-a-functions-server.md)**
+ *  **[Running a Functions Server](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.running-a-functions-server.html)**
     : How to use the `functions-framework-ruby` executable to run a local
     functions server.
- *  **[Deploying Functions](https://rubydoc.info/gems/functions_framework/file/docs/deploying-functions.md)**
+ *  **[Deploying Functions](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.deploying-functions.)**
     : How to deploy functions to
     [Google Cloud Functions](https://cloud.google.com/functions) or
     [Google Cloud Run](https://cloud.google.com/run).
 
 The library reference documentation can be found at:
-https://rubydoc.info/gems/functions_framework
+https://googlecloudplatform.github.io/functions-framework-ruby
 
 Additional examples are available in the `examples` directory:
 https://github.com/GoogleCloudPlatform/functions-framework-ruby/blob/master/examples/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ These guides provide additional getting-started information.
  *  **[Running a Functions Server](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.running-a-functions-server.html)**
     : How to use the `functions-framework-ruby` executable to run a local
     functions server.
- *  **[Deploying Functions](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.deploying-functions.)**
+ *  **[Deploying Functions](https://googlecloudplatform.github.io/functions-framework-ruby/latest/file.deploying-functions.html)**
     : How to deploy functions to
     [Google Cloud Functions](https://cloud.google.com/functions) or
     [Google Cloud Run](https://cloud.google.com/run).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -121,7 +121,7 @@ These guides provide additional getting-started information.
     [Google Cloud Run](https://cloud.google.com/run).
 
 The library reference documentation can be found at:
-https://rubydoc.info/gems/functions_framework
+https://googlecloudplatform.github.io/functions-framework-ruby
 
 Additional examples are available in the GitHub repository:
 https://github.com/GoogleCloudPlatform/functions-framework-ruby/blob/master/examples/

--- a/docs/testing-functions.md
+++ b/docs/testing-functions.md
@@ -17,9 +17,8 @@ the output. You do not need to set up (or mock) an actual server.
 The Functions Framework provides utility methods that streamline the process of
 setting up functions and the environment for testing, constructing input
 parameters, and interpreting results. These are available in the
-[Testing module](https://rubydoc.info/gems/functions_framework/FunctionsFramework/Testing).
-Generally, you can include this module in your Minitest test class or RSpec
-describe block.
+{FunctionsFramework::Testing Testing module}. Generally, you can include this
+module in your Minitest test class or RSpec describe block.
 
 ```ruby
 require "minitest/autorun"
@@ -45,10 +44,10 @@ end
 
 To test a function, you'll need to load the Ruby file that defines the function,
 and run the function to test its results. The Testing module provides a method
-[load_temporary](https://rubydoc.info/gems/functions_framework/FunctionsFramework/Testing#load_temporary-instance_method),
-which loads a Ruby file, defining functions but only for the scope of your test.
-This allows your test to coexist with tests for other functions, even functions
-with the same name from a different Ruby file.
+{FunctionsFramework::Testing#load_temporary}, which loads a Ruby file, defining
+functions but only for the scope of your test. This allows your test to coexist
+with tests for other functions, even functions with the same name from a
+different Ruby file.
 
 ```ruby
 require "minitest/autorun"
@@ -91,8 +90,8 @@ includes helper methods that you can use to create simple requests for many
 basic cases.
 
 When you have constructed an input request, use
-[call_http](https://rubydoc.info/gems/functions_framework/FunctionsFramework/Testing#call_http-instance_method)
-to call a named function, passing the request object. This method returns a
+{FunctionsFramework::Testing#call_http} to call a named function, passing the
+request object. This method returns a
 [Rack::Response](https://rubydoc.info/gems/rack/Rack/Response) that you can
 assert against.
 
@@ -142,8 +141,7 @@ end
 
 Testing a CloudEvent function works similarly. The `Testing` module provides
 methods to help construct example CloudEvent objects, which can then be passed
-to the method
-[call_event](https://rubydoc.info/gems/functions_framework/FunctionsFramework/Testing#call_event-instance_method).
+to the method {FunctionsFramework::Testing#call_event}.
 
 Unlike HTTP functions, event functions do not have a return value. Instead, you
 will need to test side effects. A common approach is to test logs by capturing

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -158,9 +158,9 @@ end
 ```
 
 The event parameter will be either a
-[CloudEvents V0.3 Event](https://rubydoc.info/gems/cloud_events/CloudEvents/Event/V0)
+[CloudEvents V0.3 Event](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event/V0)
 object ([see spec](https://github.com/cloudevents/spec/blob/v0.3/spec.md)) or a
-[CloudEvents V1.0 Event](https://rubydoc.info/gems/cloud_events/CloudEvents/Event/V1)
+[CloudEvents V1.0 Event](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event/V1)
 object ([see spec](https://github.com/cloudevents/spec/blob/v1.0/spec.md)).
 
 Some Google Cloud services send events in a legacy event format that was defined

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -47,9 +47,9 @@ version = ::FunctionsFramework::VERSION
 
   if spec.respond_to? :metadata
     spec.metadata["changelog_uri"] =
-      "https://googlecloudplatform.github.io/functions-framework-ruby/#{version}/file.CHANGELOG.html"
+      "https://googlecloudplatform.github.io/functions-framework-ruby/v#{version}/file.CHANGELOG.html"
     spec.metadata["source_code_uri"] = "https://github.com/GoogleCloudPlatform/functions-framework-ruby"
     spec.metadata["bug_tracker_uri"] = "https://github.com/GoogleCloudPlatform/functions-framework-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://googlecloudplatform.github.io/functions-framework-ruby/#{version}"
+    spec.metadata["documentation_uri"] = "https://googlecloudplatform.github.io/functions-framework-ruby/v#{version}"
   end
 end

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -17,10 +17,11 @@
 lib = File.expand_path "lib", __dir__
 $LOAD_PATH.unshift lib unless $LOAD_PATH.include? lib
 require "functions_framework/version"
+version = ::FunctionsFramework::VERSION
 
 ::Gem::Specification.new do |spec|
   spec.name = "functions_framework"
-  spec.version = ::FunctionsFramework::VERSION
+  spec.version = version
   spec.authors = ["Daniel Azuma"]
   spec.email = ["dazuma@google.com"]
 
@@ -46,10 +47,9 @@ require "functions_framework/version"
 
   if spec.respond_to? :metadata
     spec.metadata["changelog_uri"] =
-      "https://github.com/GoogleCloudPlatform/functions-framework-ruby/blob/master/CHANGELOG.md"
+      "https://googlecloudplatform.github.io/functions-framework-ruby/#{version}/file.CHANGELOG.html"
     spec.metadata["source_code_uri"] = "https://github.com/GoogleCloudPlatform/functions-framework-ruby"
     spec.metadata["bug_tracker_uri"] = "https://github.com/GoogleCloudPlatform/functions-framework-ruby/issues"
-    spec.metadata["documentation_uri"] =
-      "https://rubydoc.info/gems/functions_framework/#{::FunctionsFramework::VERSION}"
+    spec.metadata["documentation_uri"] = "https://googlecloudplatform.github.io/functions-framework-ruby/#{version}"
   end
 end

--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -147,7 +147,7 @@ module FunctionsFramework
     #
     # You must provide a name for the function, and a block that implemets the
     # function. The block should take one argument: the event object of type
-    # [`CloudEvents::Event`](https://rubydoc.info/gems/cloud_events/CloudEvents/Event).
+    # [`CloudEvents::Event`](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event).
     # Any return value is ignored.
     #
     # ## Example

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -23,7 +23,7 @@ module FunctionsFramework
   # `Rack::Request` argument and returns one of various HTTP response types.
   # See {FunctionsFramework::Registry.add_http}. For a function of type
   # `:cloud_event`, the `call` method takes a single
-  # [CloudEvent](https://rubydoc.info/gems/cloud_events/CloudEvents/Event)
+  # [CloudEvent](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event)
   # argument, and does not return a value.
   # See {FunctionsFramework::Registry.add_cloud_event}.
   #

--- a/lib/functions_framework/registry.rb
+++ b/lib/functions_framework/registry.rb
@@ -80,7 +80,7 @@ module FunctionsFramework
     #
     # You must provide a name for the function, and a block that implemets the
     # function. The block should take _one_ argument: the event object of type
-    # [`CloudEvents::Event`](https://rubydoc.info/gems/cloud_events/CloudEvents/Event).
+    # [`CloudEvents::Event`](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event).
     # Any return value is ignored.
     #
     # @param name [String] The function name


### PR DESCRIPTION
Use github pages hosted reference docs instead of rubydoc.info hosted pages.