### PR TITLE
docs: Fix instructions for deployment to Google Cloud Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ An open source framework for writing lightweight, portable Ruby functions that
 run in a serverless environment. Functions written to this Framework will run
 in many different environments, including:
 
- *  [Google Cloud Functions](https://cloud.google.com/functions) *(in preview)*
- *  [Cloud Run or Cloud Run for Anthos](https://cloud.google.com/run)
+ *  [Google Cloud Functions](https://cloud.google.com/functions) *(alpha)*
+ *  [Google Cloud Run](https://cloud.google.com/run)
  *  Any other [Knative](https://github.com/knative)-based environment
  *  Your local development machine
 

--- a/docs/deploying-functions.md
+++ b/docs/deploying-functions.md
@@ -34,7 +34,7 @@ You can run Ruby functions on Google Cloud Functions by selecting the `ruby26`
 runtime. This runtime uses a recent release of Ruby 2.6. Support for other
 versions of Ruby may be added in the future.
 
-> **Note:** Ruby support on Cloud Functions is currently in limited preview.
+> **Note:** Ruby support on Cloud Functions is currently in limited alpha.
 > It is not yet suitable for production workloads, and support is best-effort
 > only. Access is currently limited to selected early-access users.
 
@@ -46,23 +46,27 @@ is to `bundle install` or `bundle update` and run your local tests prior to
 deploying. Cloud Functions will not accept your function unless an up-to-date
 `Gemfile.lock` is present.
 
-Choose a name for your function. This function name is how it will appear in the
-cloud console, and will also be part of the function's URL. (It's different from
-the name you provide when writing your function; Cloud Functions calls that name
-the "function target".)
+Also, make sure your source file (which defines your function) is called
+`app.rb`. The Functions Framework lets you use a different source file, but
+Cloud Functions requires you to use `app.rb`.
+
+Choose a Cloud Functions name for your function. This name is how it will appear
+in the cloud console, and will also be part of the function's URL. (It is often,
+but not necessarily, the same as the name you used when writing your function--
+which Cloud Functions calls the "target".)
 
 Then, issue the gcloud command to deploy:
 
 ```sh
 gcloud functions deploy $YOUR_FUNCTION_NAME --project=$YOUR_PROJECT_ID \
-  --runtime=ruby26 --trigger-http --source=$YOUR_FUNCTION_SOURCE \
-  --entry-point=$YOUR_FUNCTION_TARGET
+  --runtime=ruby26 --trigger-http --entry-point=$YOUR_FUNCTION_TARGET
 ```
 
-The source file defaults to `./app.rb` and the function target defaults to
-`function`, so those flags can be omitted if you're using the defaults. The
-project flag can also be omitted if you've set it as the default with
-`gcloud config set project`.
+`$YOUR_FUNCTION_NAME` should be the Cloud Functions name for your function, and
+is required. `$YOUR_FUNCTION_TARGET` is the "target", i.e. the name you used
+when writing your function. It can be omitted if it is the same as
+`$YOUR_FUNCTION_NAME`. Additionally, the project flag can be omitted if you've
+set it as the default using `gcloud config set project`.
 
 If your function handles events rather than HTTP requests, you'll need to
 replace `--trigger-http` with a different trigger. For details, see the

--- a/docs/deploying-functions.md
+++ b/docs/deploying-functions.md
@@ -47,33 +47,38 @@ deploying. Cloud Functions will not accept your function unless an up-to-date
 `Gemfile.lock` is present.
 
 Also, make sure your source file (which defines your function) is called
-`app.rb`. The Functions Framework lets you use a different source file, but
-Cloud Functions requires you to use `app.rb`.
+`app.rb`. The Functions Framework lets you choose a function source file, but
+Cloud Functions currently requires you to use `app.rb`.
 
-Choose a Cloud Functions name for your function. This name is how it will appear
-in the cloud console, and will also be part of the function's URL. (It is often,
-but not necessarily, the same as the name you used when writing your function--
-which Cloud Functions calls the "target".)
+Decide _which_ function in the source file to invoke, that is, the name that you
+used when writing the function. This is called the **target**. (Note that if you
+did not specify a name for the function, it defaults to the name `function`.)
+
+Choose a Cloud Functions **name** for your function. The **name** identifies
+this function deployment (e.g. in the cloud console) and is also part of the
+function's default URL. (Note: the **name** and the **target** do not have to
+be the same value.)
 
 Then, issue the gcloud command to deploy:
 
 ```sh
-gcloud functions deploy $YOUR_FUNCTION_NAME --project=$YOUR_PROJECT_ID \
-  --runtime=ruby26 --trigger-http --entry-point=$YOUR_FUNCTION_TARGET
+gcloud functions deploy $YOUR_FUNCTION_NAME \
+    --project=$YOUR_PROJECT_ID \
+    --runtime=ruby26 \
+    --trigger-http \
+    --entry-point=$YOUR_FUNCTION_TARGET
 ```
 
-`$YOUR_FUNCTION_NAME` should be the Cloud Functions name for your function, and
-is required. `$YOUR_FUNCTION_TARGET` is the "target", i.e. the name you used
-when writing your function. It can be omitted if it is the same as
-`$YOUR_FUNCTION_NAME`. Additionally, the project flag can be omitted if you've
-set it as the default using `gcloud config set project`.
+The `--entry-point=` flag can be omitted if the **target** has the same value
+as the **name**. Additionally, the `--project` flag can be omitted if you've
+set your default project using `gcloud config set project`.
 
 If your function handles events rather than HTTP requests, you'll need to
 replace `--trigger-http` with a different trigger. For details, see the
 [reference documentation](https://cloud.google.com/sdk/gcloud/reference/functions/deploy)
 for `gcloud functions deploy`.
 
-To update your deployment, just redeploy using the same function name.
+To update your deployment, just redeploy using the same function **name**.
 
 ### Configuring Cloud Functions deployments
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,8 +8,8 @@ The Functions Framework is an open source framework for writing lightweight,
 portable Ruby functions that run in a serverless environment. Functions written
 to this Framework will run in many different environments, including:
 
- *  [Google Cloud Functions](https://cloud.google.com/functions) *(in preview)*
- *  [Cloud Run or Cloud Run for Anthos](https://cloud.google.com/run)
+ *  [Google Cloud Functions](https://cloud.google.com/functions) *(alpha)*
+ *  [Google Cloud Run](https://cloud.google.com/run)
  *  Any other [Knative](https://github.com/knative)-based environment
  *  Your local development machine
 

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -28,6 +28,7 @@ an HTTP response. The following example defines an HTTP function named "hello"
 that returns a simple message in the HTTP response body:
 
 ```ruby
+# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "hello" do |request|
@@ -49,6 +50,7 @@ Rack environment using the `env` method. The following example includes some
 request information in the response:
 
 ```ruby
+# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "request_info_example" do |request|
@@ -64,6 +66,7 @@ Google Cloud Logs if your function is running on a Google Cloud serverless
 hosting environment.
 
 ```ruby
+# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "logging_example" do |request|
@@ -121,6 +124,7 @@ Write the Sinatra app using the "modular" Sinatra interface (i.e. subclass
 the function. Here is a basic example:
 
 ```ruby
+# app.rb
 require "functions_framework"
 require "sinatra/base"
 
@@ -150,6 +154,7 @@ The following is a simple event handler that receives an event and logs some
 information about it:
 
 ```ruby
+# app.rb
 require "functions_framework"
 
 FunctionsFramework.cloud_event "hello" do |event|
@@ -187,6 +192,7 @@ If you need more control over the error response, you can also construct the
 HTTP response yourself. For example:
 
 ```ruby
+# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "error_reporter" do |request|
@@ -208,12 +214,12 @@ defines functions, and can also include additional Ruby files defining classes
 and methods that assist in the function implementation.
 
 The "entrypoint" to the project, also called the "source", is a Ruby file. It
-can define any number of functions (with distinct names), although it is often
-good practice to create a separate Ruby file per function.
+can define any number of functions (with distinct names).
 
-By convention, the source file is often called `app.rb`, but you can give it
-any name. Projects can also have multiple source files that apply to different
-cases.
+By convention, the source file should generally be called `app.rb` and be
+located at the root of the project. The Functions Framework allows you to use a
+different name, but some hosting environments (such as Google Cloud Functions)
+require the name to be `app.rb`.
 
 A simple project might look like this:
 

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -28,7 +28,6 @@ an HTTP response. The following example defines an HTTP function named "hello"
 that returns a simple message in the HTTP response body:
 
 ```ruby
-# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "hello" do |request|
@@ -50,7 +49,6 @@ Rack environment using the `env` method. The following example includes some
 request information in the response:
 
 ```ruby
-# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "request_info_example" do |request|
@@ -66,7 +64,6 @@ Google Cloud Logs if your function is running on a Google Cloud serverless
 hosting environment.
 
 ```ruby
-# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "logging_example" do |request|
@@ -113,7 +110,6 @@ It is easy to connect an HTTP function to a Sinatra app. First, declare the
 dependency on Sinatra in your `Gemfile`:
 
 ```ruby
-# Gemfile
 source "https://rubygems.org"
 gem "functions_framework", "~> 0.5"
 gem "sinatra", "~> 2.0"
@@ -124,7 +120,6 @@ Write the Sinatra app using the "modular" Sinatra interface (i.e. subclass
 the function. Here is a basic example:
 
 ```ruby
-# app.rb
 require "functions_framework"
 require "sinatra/base"
 
@@ -154,7 +149,6 @@ The following is a simple event handler that receives an event and logs some
 information about it:
 
 ```ruby
-# app.rb
 require "functions_framework"
 
 FunctionsFramework.cloud_event "hello" do |event|
@@ -192,7 +186,6 @@ If you need more control over the error response, you can also construct the
 HTTP response yourself. For example:
 
 ```ruby
-# app.rb
 require "functions_framework"
 
 FunctionsFramework.http "error_reporter" do |request|
@@ -213,15 +206,14 @@ needed by the function. It must include at least one Ruby source file that
 defines functions, and can also include additional Ruby files defining classes
 and methods that assist in the function implementation.
 
-The "entrypoint" to the project, also called the "source", is a Ruby file. It
-can define any number of functions (with distinct names).
+By convention, the "main" Ruby file that defines functions should be called
+`app.rb` and be located at the root of the project. The path to this file is
+sometimes known as the **function source**. The Functions Framework allows you
+to specify an arbitrary source, but suome hosting environments (such as Google
+Cloud Functions) require it to be `./app.rb`.
 
-By convention, the source file should generally be called `app.rb` and be
-located at the root of the project. The Functions Framework allows you to use a
-different name, but some hosting environments (such as Google Cloud Functions)
-require the name to be `app.rb`.
-
-A simple project might look like this:
+A source file can define any number of functions (with distinct names). Each of
+the names is known as a **function target**.
 
 ```
 (project directory)

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -27,7 +27,11 @@ version = ::FunctionsFramework::VERSION
 
   spec.summary = "Functions Framework for Ruby"
   spec.description =
-    "The Functions Framework implementation for Ruby."
+    "The Functions Framework is an open source framework for writing" \
+    " lightweight, portable Ruby functions that run in a serverless" \
+    " environment. Functions written to this Framework will run Google Cloud" \
+    " Google Cloud Functions, Google Cloud Run, or any other Knative-based" \
+    " environment."
   spec.license = "Apache-2.0"
   spec.homepage = "https://github.com/GoogleCloudPlatform/functions-framework-ruby"
 


### PR DESCRIPTION
* The deployment docs incorrectly said that you could specify the file that defines the function when deploying to Cloud Functions. This is not true for Ruby, and the docs have been fixed.
* The release status for Ruby on Cloud Functions was incorrectly described as "preview", but should be "alpha". Fixed.
* Updated the gem's long description to be a bit more detailed.