### PR TITLE
Use global $stderr rather than STDERR for logger

### DIFF
--- a/lib/functions_framework.rb
+++ b/lib/functions_framework.rb
@@ -71,7 +71,7 @@ require "functions_framework/version"
 #
 module FunctionsFramework
   @global_registry = Registry.new
-  @logger = ::Logger.new ::STDERR
+  @logger = ::Logger.new $stderr
   @logger.level = ::Logger::INFO
 
   ##


### PR DESCRIPTION
# The Problem

Currently the logger uses `::STDERR` as it's log device. This poses a problem when you'd like to capture or suppress those logs (typically when testing).

By using `$stderr` instead (which by default is set to equal `::STDERR`), we'd be able to dynamically change the device if/when desired.

# The Solution

Update the log device to be `$stderr` allowing functions like the following to be used to silence output in tests.

```ruby
def capture_io
  $stdout = StringIO.new
  $stderr = StringIO.new
  yield
ensure
  $stdout = ::STDOUT
  $stderr = ::STDERR
end
```