### PR TITLE
feat: Implement verification function (3 commits)

### DIFF
--- a/bin/functions-framework
+++ b/bin/functions-framework
@@ -16,4 +16,4 @@
 
 require "functions_framework/cli"
 
-::FunctionsFramework::CLI.new.parse_args(::ARGV).run
+::FunctionsFramework::CLI.new.parse_args(::ARGV).run.complete

--- a/bin/functions-framework-ruby
+++ b/bin/functions-framework-ruby
@@ -16,4 +16,4 @@
 
 require "functions_framework/cli"
 
-::FunctionsFramework::CLI.new.parse_args(::ARGV).run
+::FunctionsFramework::CLI.new.parse_args(::ARGV).run.complete

--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -82,9 +82,9 @@ module FunctionsFramework
           @server.max_threads = @config.max_threads
           @server.leak_stack_on_error = @config.show_error_details?
           @server.binder.add_tcp_listener @config.bind_addr, @config.port
-          @server.run true
           @config.logger.info "FunctionsFramework: Serving function #{@function.name.inspect}" \
                               " on port #{@config.port}..."
+          @server.run true
         end
       end
       self

--- a/test/function_definitions/startup_block.rb
+++ b/test/function_definitions/startup_block.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "functions_framework"
+
+my_global = false
+
+# Startup block
+FunctionsFramework.on_startup do |function, _config|
+  my_global = function.name == "simple_http"
+  puts "in startup block"
+end
+
+# Create a simple HTTP function called "simple_http"
+FunctionsFramework.http "simple_http" do |_request|
+  raise "Whoops" unless my_global
+  "OK"
+end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -58,6 +58,26 @@ describe FunctionsFramework::CLI do
     ENV["FUNCTION_SIGNATURE_TYPE"] = nil
   end
 
+  it "prints the version when given the --version flag" do
+    args = [
+      "--version"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    assert_output "#{FunctionsFramework::VERSION}\n" do
+      cli.run
+    end
+  end
+
+  it "prints online help when given the --help flag" do
+    args = [
+      "--help"
+    ]
+    cli = FunctionsFramework::CLI.new.parse_args args
+    assert_output(/^Usage:/) do
+      cli.run
+    end
+  end
+
   it "runs an http server" do
     args = [
       "--source", http_source,


### PR DESCRIPTION
Important: rebase when merging, rather than squash, so the three conventional commit messages get into the history.

This implements a verification function that will be used by the GCF build process to determine that the Ruby code is syntactically well-formed and actually defines the function it wants to use. It comprises three commits that will show up in the changelog:

* **feat: You can use the --version flag to print the framework version**
    * Implements a `--version` flag that prints the framework version. This will be used by the GCF buildpack to validate minimum framework version.
    * Refactor of the CLI run process so that `--help` and `--version` print their output during `run` rather than `parse_args`. This makes it possible to test those flags since they don't have to `Kernel.exit`.
    * Provide tests for `--help` and `--version` flags.
* **feat: You can use the --verify flag to verify that a given function is defined**
    * Implements the `--verify` flag that loads the code and validates the requested function but doesn't actually run the server.
    * Separate out the error reporting into a separate method `complete`, and provide accessors for error status. This makes it possible to test flags that report error status.
    * Fixes for option parser error detection.
    * Add tests for `--verify` as well as optparse errors.
* **feat: You can now define blocks that are executed at server startup**
    * This feature would have to be provided alongside verification because customers will want to perform global initialization (e.g. database connections) and will naturally do those at the top level of the Ruby file. But with verification, the Ruby file gets loaded at deploy/build time, which will attempt to create those connections at a time when they will probably fail. So we provide (and document) a mechanism to defer that initialization to just before the server actually starts.
    * Implements the feature
    * Adds tests
    * Adds a section to the "Writing a function" documentation file