### PR TITLE
release: Release functions_framework 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v0.6.0 / 2020-09-17
+
+* ADDED: You can use the --version flag to print the framework version
+* ADDED: You can use the --verify flag to verify that a given function is defined
+* ADDED: You can now define blocks that are executed at server startup
+
 ### v0.5.2 / 2020-09-06
 
 * FIXED: Use global $stderr rather than STDERR for logger 

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.5.2".freeze
+  VERSION = "0.6.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 0.6.0** (was 0.5.2)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v0.6.0 / 2020-09-17

* ADDED: You can use the --version flag to print the framework version
* ADDED: You can use the --verify flag to verify that a given function is defined
* ADDED: You can now define blocks that are executed at server startup
