### PR TITLE
feat!: Rework globals mechanism to better support shared resources

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "2.4"
-            flags: "--only --test-unit"
-          - os: ubuntu-latest
             ruby: "2.5"
             flags: "--only --test-unit"
           - os: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   google-style: google-style.yml
 
 AllCops:
+  TargetRubyVersion: 2.5
   Include:
     - "examples/**/.toys.rb"
     - "**/*.rb"

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ requiring an HTTP server or complicated request handling logic.
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.5+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.4
+in security maintenance, and not end of life. Currently, this means Ruby 2.5
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -64,7 +64,7 @@ Create a `Gemfile` listing the Functions Framework as a dependency:
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.5"
+gem "functions_framework", "~> 0.7"
 ```
 
 Create a file called `app.rb` and include the following code. This defines a

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -46,11 +46,11 @@ requiring an HTTP server or complicated request handling logic.
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.5+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life. Currently, this means Ruby 2.4
+in security maintenance, and not end of life. Currently, this means Ruby 2.5
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/docs/testing-functions.md
+++ b/docs/testing-functions.md
@@ -179,17 +179,22 @@ You can also call startup tasks explicitly to test them in isolation, using the
 function, and the testing module will execute all defined startup blocks, in
 order, as if the server were preparing that function for execution.
 {FunctionsFramework::Testing#run_startup_tasks} returns the resulting globals
-as a hash, and you can assert against its contents.
+as a hash, so you can assert against its contents.
 
 If you use {FunctionsFramework::Testing#run_startup_tasks} to run the startup
 tasks explicitly, they will not be run again when you call the function itself
 using {FunctionsFramework::Testing#call_http} or
-{FunctionsFramework::Testing#call_event}.
+{FunctionsFramework::Testing#call_event}. However, if startup tasks have
+already been run implicitly by {FunctionsFramework::Testing#call_http} or
+{FunctionsFramework::Testing#call_event}, then attempting to run them again
+explicitly by calling {FunctionsFramework::Testing#run_startup_tasks} will
+result in an exception.
 
-There is currently no way to run a single startup block in isolation.
+There is currently no way to run a single startup block in isolation. If you
+have multiple startup blocks defined, they are always executed together.
 
 Following is an example test that runs startup tasks explicitly and asserts
-against its effects on the globals.
+against the effect on the globals.
 
 ```ruby
 require "minitest/autorun"

--- a/docs/testing-functions.md
+++ b/docs/testing-functions.md
@@ -165,3 +165,35 @@ class MyTest < Minitest::Test
   end
 end
 ```
+
+## Testing startup tasks
+
+When a functions server is starting up, it calls startup tasks automatically.
+However, the testing environment does not do this. You must call startup tasks
+explicitly in order to test them, and to prepare any shared resources needed by
+the function to be tested.
+
+To call startup tasks, pass the function name to the method
+{FunctionsFramework::Testing#run_startup_tasks}. This will execute all defined
+startup tasks as if the server were preparing the given function for execution.
+It will also return the {FunctionsFramework::Function} object so you can
+inspect it.
+
+```ruby
+require "minitest/autorun"
+require "functions_framework/testing"
+
+class MyTest < Minitest::Test
+  include FunctionsFramework::Testing
+
+  def test_startup_tasks
+    load_temporary "app.rb" do
+      run_startup_tasks "my_function"
+
+      request = make_get_request "https://example.com/foo"
+      response = call_http "my_function", request
+      assert_equal 200, response.status
+    end
+  end
+end
+```

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -215,7 +215,7 @@ FunctionsFramework.on_startup do |function|
 end
 
 FunctionsFramework.http "hello" do |request|
-  # Use MyCache during thie
+  # Initialization will be done by the time a normal function is called.
 end
 ```
 

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -249,7 +249,7 @@ require "functions_framework"
 
 # Instead initialize in an on_startup block, which is executed only when a
 # runtime server is starting up.
-FunctionsFramework.on_startup do
+FunctionsFramework.on_startup do |function|
   # Perform initialization here.
   require "my_cache"
   MyCache.warmup

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -210,12 +210,12 @@ most out of a cloud serverless product.
 
 For example, multithreading is a core element of the Functions Framework. When
 you write functions, you should assume that multiple executions may be taking
-place concurrently in different threads, and you should avoid operations that
-can cause concurrency issues or race conditions. The easiest way to do this is
-to make your functions self-contained and stateless. Avoid global variables and
-don't share mutable data between different function executions.
+place concurrently in different threads, and thus you should avoid operations
+that can cause concurrency issues or race conditions. The easiest way to do
+this is to make your functions self-contained and stateless. Avoid global
+variables and don't share mutable data between different function executions.
 
-Additionally, the serverless runtime may throttle the CPU whenever no actual
+Additionally, a serverless runtime may throttle the CPU whenever no actual
 function executions are taking place. This lets it reduce the CPU resources
 used (and therefore the cost to you), while keeping your application warmed up
 and ready to respond to new requests quickly. An important implication, though,
@@ -258,15 +258,15 @@ the function that will be run. You code can, for example, perform different
 initialization depending on the {FunctionsFramework::Function#name} or
 {FunctionsFramework::Function#type}.
 
-In most cases, initialization code should live in an `on_startup` block
-_instead of_ at the "top level" of your Ruby file that defines functions. This
-is because some serverless runtimes may load your Ruby file at build or
-deployment time (for example, to verify that the requested function is properly
-defined), which will execute any code present at the top level of the Ruby
-file. If your initialization is long-running or depends on runtime resources or
-environment variables, this could cause the deployment to fail. By performing
-initialization in an `on_startup` block instead, you ensure it will run only
-when an actual runtime server is starting up, not at build/deployment time.
+**In most cases, initialization code should live in an `on_startup` block
+instead of at the "top level" of your Ruby file.** This is because some
+serverless runtimes may load your Ruby code at build or deployment time (for
+example, to verify that it properly defines the requested function), and this
+will execute any code present at the top level of the Ruby file. If top-level
+code is long-running or depends on runtime resources or environment variables,
+this could cause the deployment to fail. By performing initialization in an
+`on_startup` block instead, you ensure it will run only when an actual runtime
+server is starting up, not at build/deployment time.
 
 ```ruby
 require "functions_framework"
@@ -330,9 +330,9 @@ resources, as described below.
 
 Using the global data mechanism is generally preferred over actual Ruby global
 variables, because the Functions Framework can help you avoid concurrent edits.
-Additionally, the framework will sandbox different sets of global data
-associated with different sets of functions, which lets you test functions in
-isolation without the tests interfering with one another.
+Additionally, the framework will isolate the sets of global data associated
+with different sets of functions, which lets you test functions in isolation
+without the tests interfering with one another by writing to global variables.
 
 ### Sharing resources
 
@@ -344,11 +344,11 @@ it across function invocations to avoid incurring the overhead of
 re-establishing it for every function invocation.
 
 The best practice for sharing a resource across function invocations is to
-initialize shared resources in a {FunctionsFramework.on_startup} block, and
-reference them from global shared data. (As discussed above, prefer to
-initialize shared resources in a startup task rather than at the top level of a
-Ruby file, and prefer using the Functions Framework's global data mechanism
-rather than Ruby global variables.)
+initialize it in a {FunctionsFramework.on_startup} block, and reference it from
+global shared data. (As discussed above, prefer to initialize shared resources
+in a startup task rather than at the top level of a Ruby file, and prefer using
+the Functions Framework's global data mechanism rather than Ruby's global
+variables.)
 
 Here is a simple example:
 
@@ -380,7 +380,7 @@ Also of note: There is no guaranteed cleanup hook. The Functions Framework does
 not provide a way to register a cleanup task, and we recommend against using
 resources that require explicit "cleanup". This is because serverless runtimes
 may perform CPU throttling, and therefore there may not be an opportunity for
-cleanup tasks to run. (For example, you can register a `Kernel.at_exit` task,
+cleanup tasks to run. (For example, you could register a `Kernel.at_exit` task,
 but the Ruby VM may still terminate without calling it.)
 
 ## Structuring a project

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -44,7 +44,7 @@ version = ::FunctionsFramework::VERSION
   spec.bindir = "bin"
   spec.executables = ["functions-framework", "functions-framework-ruby"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
   spec.add_dependency "cloud_events", "~> 0.1"
   spec.add_dependency "puma", "~> 4.3"
   spec.add_dependency "rack", "~> 2.1"

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -29,8 +29,8 @@ version = ::FunctionsFramework::VERSION
   spec.description =
     "The Functions Framework is an open source framework for writing" \
     " lightweight, portable Ruby functions that run in a serverless" \
-    " environment. Functions written to this Framework will run Google Cloud" \
-    " Google Cloud Functions, Google Cloud Run, or any other Knative-based" \
+    " environment. Functions written to this Framework will run on Google" \
+    " Cloud Functions, Google Cloud Run, or any other Knative-based" \
     " environment."
   spec.license = "Apache-2.0"
   spec.homepage = "https://github.com/GoogleCloudPlatform/functions-framework-ruby"

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -18,40 +18,87 @@ module FunctionsFramework
   #
   # A function has a name, a type, and an implementation.
   #
+  # ## Function implementations
+  #
   # The implementation in general is an object that responds to the `call`
-  # method. For a function of type `:http`, the `call` method takes a single
-  # `Rack::Request` argument and returns one of various HTTP response types.
-  # See {FunctionsFramework::Registry.add_http}. For a function of type
-  # `:cloud_event`, the `call` method takes a single
-  # [CloudEvent](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event)
-  # argument, and does not return a value.
-  # See {FunctionsFramework::Registry.add_cloud_event}.
+  # method.
   #
-  # If a callable object is provided directly, its `call` method is invoked for
-  # every function execution. Note that this means it may be called multiple
-  # times concurrently in separate threads.
+  #  *  For a function of type `:http`, the `call` method takes a single
+  #     `Rack::Request` argument and returns one of various HTTP response
+  #     types. See {FunctionsFramework::Registry.add_http}.
+  #  *  For a function of type `:cloud_event`, the `call` method takes a single
+  #     [CloudEvent](https://cloudevents.github.io/sdk-ruby/latest/CloudEvents/Event)
+  #     argument, and does not return a value. See
+  #     {FunctionsFramework::Registry.add_cloud_event}.
+  #  *  For a function of type `:startup_task`, the `call` method takes a
+  #     single {FunctionsFramework::Function} argument, and does not return a
+  #     value. See {FunctionsFramework::Registry.add_startup_task}.
   #
-  # Alternately, the implementation may be provided as a class that should be
-  # instantiated to produce a callable object. If a class is provided, it should
-  # either subclass {FunctionsFramework::Function::CallBase} or respond to the
-  # same constructor interface, i.e. accepting arbitrary keyword arguments. A
-  # separate callable object will be instantiated from this class for every
-  # function invocation, so each instance will be used for only one invocation.
+  # The implementation can be specified in one of three ways:
   #
-  # Finally, an implementation can be provided as a block. If a block is
-  # provided, it will be recast as a `call` method in an anonymous subclass of
-  # {FunctionsFramework::Function::CallBase}. Thus, providing a block is really
-  # just syntactic sugar for providing a class. (This means, for example, that
-  # the `return` keyword will work within the block because it is treated as a
-  # method.)
+  #  *  A callable object can be passed in the `callable` keyword argument. The
+  #     object's `call` method will be invoked for every function execution.
+  #     Note that this means it may be called multiple times concurrently in
+  #     separate threads.
+  #  *  A callable _class_ can be passed in the `callable` keyword argument.
+  #     This class should subclass {FunctionsFramework::Function::Callable} and
+  #     define the `call` method. A separate instance of this class will be
+  #     created for each function invocation.
+  #  *  A block can be provided. It will be used to define the `call` method in
+  #     an anonymous subclass of {FunctionsFramework::Function::Callable}.
+  #     Thus, providing a block is really just syntactic sugar for providing a
+  #     class. (This means, for example, that the `return` keyword will work
+  #     as expected within the block because it is treated as a method.)
+  #
+  # When the implementation is provided as a callable class or block, it is
+  # executed in the context of a {FunctionsFramework::Function::Callable}
+  # object. This object provides a convenience accessor for the Logger, and
+  # access to _globals_, which are data defined by the application startup
+  # process and available to each function invocation. Typically, globals are
+  # used for shared global resources such as service connections and clients.
   #
   class Function
+    ##
+    # Create a new HTTP function definition.
+    #
+    # @param name [String] The function name
+    # @param callable [Class,#call] A callable object or class.
+    # @param block [Proc] The function code as a block.
+    # @return [FunctionsFramework::Function]
+    #
+    def self.http name, callable = nil, &block
+      new name, :http, callable, &block
+    end
+
+    ##
+    # Create a new CloudEvents function definition.
+    #
+    # @param name [String] The function name
+    # @param callable [Class,#call] A callable object or class.
+    # @param block [Proc] The function code as a block.
+    # @return [FunctionsFramework::Function]
+    #
+    def self.cloud_event name, callable = nil, &block
+      new name, :cloud_event, callable, &block
+    end
+
+    ##
+    # Create a new startup task function definition.
+    #
+    # @param callable [Class,#call] A callable object or class.
+    # @param block [Proc] The function code as a block.
+    # @return [FunctionsFramework::Function]
+    #
+    def self.startup_task callable = nil, &block
+      new nil, :startup_task, callable, &block
+    end
+
     ##
     # Create a new function definition.
     #
     # @param name [String] The function name
-    # @param type [Symbol] The type of function. Valid types are `:http` and
-    #     `:cloud_event`.
+    # @param type [Symbol] The type of function. Valid types are `:http`,
+    #     `:cloud_event`, and `:startup_task`.
     # @param callable [Class,#call] A callable object or class.
     # @param block [Proc] The function code as a block.
     #
@@ -64,7 +111,7 @@ module FunctionsFramework
       elsif callable.is_a? ::Class
         @callable_class = callable
       elsif block_given?
-        @callable_class = ::Class.new CallBase do
+        @callable_class = ::Class.new Callable do
           define_method :call, &block
         end
       else
@@ -83,6 +130,18 @@ module FunctionsFramework
     attr_reader :type
 
     ##
+    # Populate the given globals hash with this function's info.
+    #
+    # @param globals [Hash] Initial globals hash (optional).
+    # @return [Hash] A new globals hash with this function's info included.
+    #
+    def populate_globals globals = nil
+      result = { function_name: name, function_type: type }
+      result.merge! globals if globals
+      result
+    end
+
+    ##
     # Get a callable for performing a function invocation. This will either
     # return the singleton callable object, or instantiate a new callable from
     # the configured class.
@@ -91,10 +150,9 @@ module FunctionsFramework
     #     may or may not be used by the callable.
     # @return [#call]
     #
-    def new_call logger: nil
-      return @callable unless @callable.nil?
-      logger ||= FunctionsFramework.logger
-      @callable_class.new logger: logger, function_name: name, function_type: type
+    def call *args, globals: nil, logger: nil
+      callable = @callable || @callable_class.new(globals: globals, logger: logger)
+      callable.call(*args)
     end
 
     ##
@@ -102,29 +160,56 @@ module FunctionsFramework
     #
     # An object of this class is `self` while a function block is running.
     #
-    class CallBase
+    class Callable
       ##
       # Create a callable object with the given context.
       #
-      # @param context [keywords] A set of context arguments. See {#context} for
-      #     a list of keys that will generally be passed in. However,
-      #     implementations should be prepared to accept any abritrary keys.
+      # @param globals [Hash] A set of globals available to the call.
+      # @param logger [Logger] A logger for use by the function call.
       #
-      def initialize **context
-        @context = context
+      def initialize globals: nil, logger: nil
+        @__globals = globals || {}
+        @__logger = logger || FunctionsFramework.logger
       end
 
       ##
-      # A keyed hash of context information. Common context keys include:
+      # Get the given named global.
       #
-      #  *  **:logger** (`Logger`) A logger for use by this function call.
+      # For most function calls, the following globals will be defined:
+      #
       #  *  **:function_name** (`String`) The name of the running function.
       #  *  **:function_type** (`Symbol`) The type of the running function,
       #     either `:http` or `:cloud_event`.
       #
-      # @return [Hash]
+      # You can also set additional globals from a startup task.
       #
-      attr_reader :context
+      # @param key [Symbol,String] The name of the global to get.
+      # @return [Object]
+      #
+      def global key
+        @__globals[key]
+      end
+
+      ##
+      # Set a global. This can be called from startup tasks, but the globals
+      # are frozen when the server starts, so this call will raise an exception
+      # if called from a normal function.
+      #
+      # @param key [Symbol,String]
+      # @param value [Object]
+      #
+      def set_global key, value
+        @__globals[key] = value
+      end
+
+      ##
+      # A logger for use by this call.
+      #
+      # @return [Logger]
+      #
+      def logger
+        @__logger
+      end
     end
   end
 end

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -66,8 +66,8 @@ module FunctionsFramework
     # @param block [Proc] The function code as a block.
     # @return [FunctionsFramework::Function]
     #
-    def self.http name, callable = nil, &block
-      new name, :http, callable, &block
+    def self.http name, callable: nil, &block
+      new name, :http, callable: callable, &block
     end
 
     ##
@@ -78,8 +78,8 @@ module FunctionsFramework
     # @param block [Proc] The function code as a block.
     # @return [FunctionsFramework::Function]
     #
-    def self.cloud_event name, callable = nil, &block
-      new name, :cloud_event, callable, &block
+    def self.cloud_event name, callable: nil, &block
+      new name, :cloud_event, callable: callable, &block
     end
 
     ##
@@ -89,8 +89,8 @@ module FunctionsFramework
     # @param block [Proc] The function code as a block.
     # @return [FunctionsFramework::Function]
     #
-    def self.startup_task callable = nil, &block
-      new nil, :startup_task, callable, &block
+    def self.startup_task callable: nil, &block
+      new nil, :startup_task, callable: callable, &block
     end
 
     ##
@@ -102,7 +102,7 @@ module FunctionsFramework
     # @param callable [Class,#call] A callable object or class.
     # @param block [Proc] The function code as a block.
     #
-    def initialize name, type, callable = nil, &block
+    def initialize name, type, callable: nil, &block
       @name = name
       @type = type
       @callable = @callable_class = nil
@@ -150,7 +150,7 @@ module FunctionsFramework
     # than are provided, an ArgumentError is raised.
     #
     # @param args [Array] Argument to pass to the function.
-    # @param logger [::Logger] Logger for use by function executions.
+    # @param logger [Logger] Logger for use by function executions.
     # @param globals [Hash] Globals for the function execution context
     # @return [Object] The function return value.
     #

--- a/lib/functions_framework/function.rb
+++ b/lib/functions_framework/function.rb
@@ -142,16 +142,25 @@ module FunctionsFramework
     end
 
     ##
-    # Get a callable for performing a function invocation. This will either
-    # return the singleton callable object, or instantiate a new callable from
-    # the configured class.
+    # Call the function given a set of arguments. Set the given logger and/or
+    # globals in the context if the callable supports it.
     #
-    # @param logger [::Logger] The logger for use by function executions. This
-    #     may or may not be used by the callable.
-    # @return [#call]
+    # If the given arguments exceeds what the function will accept, the args
+    # are silently truncated. However, if the function requires more arguments
+    # than are provided, an ArgumentError is raised.
+    #
+    # @param args [Array] Argument to pass to the function.
+    # @param logger [::Logger] Logger for use by function executions.
+    # @param globals [Hash] Globals for the function execution context
+    # @return [Object] The function return value.
     #
     def call *args, globals: nil, logger: nil
       callable = @callable || @callable_class.new(globals: globals, logger: logger)
+      params = callable.method(:call).parameters.map(&:first)
+      unless params.include? :rest
+        max_params = params.count(:req) + params.count(:opt)
+        args = args.take max_params
+      end
       callable.call(*args)
     end
 

--- a/test/function_definitions/simple_event.rb
+++ b/test/function_definitions/simple_event.rb
@@ -16,5 +16,5 @@ require "functions_framework"
 
 # Create a simple CloudEvents function called "simple_event"
 FunctionsFramework.cloud_event "simple_event" do |event|
-  FunctionsFramework.logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
+  logger.info "I received #{event.data.inspect} in an event of type #{event.type}"
 end

--- a/test/function_definitions/simple_http.rb
+++ b/test/function_definitions/simple_http.rb
@@ -17,6 +17,6 @@ require "functions_framework"
 # Create a simple HTTP function called "simple_http"
 FunctionsFramework.http "simple_http" do |request|
   message = "I received a request: #{request.request_method} #{request.url}"
-  request.logger.info message
+  logger.info message
   message
 end

--- a/test/function_definitions/startup_block.rb
+++ b/test/function_definitions/startup_block.rb
@@ -17,7 +17,7 @@ require "functions_framework"
 # Startup block
 FunctionsFramework.on_startup do |function|
   set_global :my_name, function.name
-  puts "in startup block"
+  logger.info "in startup block"
 end
 
 # Create a simple HTTP function called "simple_http"

--- a/test/function_definitions/startup_block.rb
+++ b/test/function_definitions/startup_block.rb
@@ -14,16 +14,14 @@
 
 require "functions_framework"
 
-my_global = false
-
 # Startup block
-FunctionsFramework.on_startup do |function, _config|
-  my_global = function.name == "simple_http"
+FunctionsFramework.on_startup do |function|
+  set_global :my_name, function.name
   puts "in startup block"
 end
 
 # Create a simple HTTP function called "simple_http"
 FunctionsFramework.http "simple_http" do |_request|
-  raise "Whoops" unless my_global
+  raise "Whoops" unless global(:my_name) == "simple_http"
   "OK"
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -237,16 +237,16 @@ describe FunctionsFramework::CLI do
     args = [
       "--source", startup_source,
       "--target", "simple_http",
-      "--port", port,
-      "-q"
+      "--port", port
     ]
     cli = FunctionsFramework::CLI.new.parse_args args
     response = nil
-    assert_output "in startup block\n" do
+    _out, err = capture_subprocess_io do
       response = run_with_retry cli do
         Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
       end
     end
+    assert_match(/in startup block/, err)
     assert_equal "200", response.code
     assert_equal "OK", response.body
   end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -34,12 +34,10 @@ describe FunctionsFramework::CLI do
     begin
       last_error = nil
       retry_count.times do
-        begin
-          return yield
-        rescue ::SystemCallError => e
-          last_error = e
-          sleep retry_interval
-        end
+        return yield
+      rescue ::SystemCallError => e
+        last_error = e
+        sleep retry_interval
       end
       raise last_error
     ensure

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -38,6 +38,7 @@ describe FunctionsFramework::CLI do
           return yield
         rescue ::SystemCallError => e
           last_error = e
+          sleep retry_interval
         end
       end
       raise last_error

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -42,7 +42,7 @@ describe FunctionsFramework::Function do
 
   it "defines a cloud_event function using a block" do
     tester = self
-    function = FunctionsFramework::Function.new "my_event_func", :cloud_event do |event|
+    function = FunctionsFramework::Function.cloud_event "my_event_func" do |event|
       tester.assert_equal "the-event", event
       tester.assert_equal "my_event_func", global(:function_name)
       "ok"
@@ -50,6 +50,17 @@ describe FunctionsFramework::Function do
     assert_equal "my_event_func", function.name
     assert_equal :cloud_event, function.type
     function.call "the-event", globals: { function_name: function.name }
+  end
+
+  it "defines a startup function using a block" do
+    tester = self
+    function = FunctionsFramework::Function.startup_task do |func|
+      tester.assert_equal "the-function", func
+      tester.assert_nil global(:function_name)
+    end
+    assert_nil function.name
+    assert_equal :startup_task, function.type
+    function.call "the-function", globals: { function_name: function.name }
   end
 
   it "represents an http function using an object" do
@@ -79,5 +90,13 @@ describe FunctionsFramework::Function do
     assert_equal :http, function.type
     response = function.call "the-request"
     assert_equal "hello", response
+  end
+
+  it "can call a startup function with no formal argument" do
+    tester = self
+    function = FunctionsFramework::Function.startup_task do
+      tester.assert_nil global(:function_name)
+    end
+    function.call "the-function", globals: { function_name: function.name }
   end
 end

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -68,7 +68,7 @@ describe FunctionsFramework::Function do
       assert_equal "the-request", request
       "hello"
     end
-    function = FunctionsFramework::Function.new "my_func", :http, callable
+    function = FunctionsFramework::Function.http "my_func", callable: callable
     assert_equal "my_func", function.name
     assert_equal :http, function.type
     response = function.call "the-request"
@@ -85,7 +85,7 @@ describe FunctionsFramework::Function do
       end
     end
 
-    function = FunctionsFramework::Function.new "my_func", :http, MyCallable
+    function = FunctionsFramework::Function.http "my_func", callable: MyCallable
     assert_equal "my_func", function.name
     assert_equal :http, function.type
     response = function.call "the-request"
@@ -98,5 +98,14 @@ describe FunctionsFramework::Function do
       tester.assert_nil global(:function_name)
     end
     function.call "the-function", globals: { function_name: function.name }
+  end
+
+  it "sets a global from a startup task" do
+    function = FunctionsFramework::Function.startup_task do
+      set_global :foo, :bar
+    end
+    globals = {}
+    function.call "the-function", globals: globals
+    assert_equal :bar, globals[:foo]
   end
 end

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -18,25 +18,25 @@ require "ostruct"
 describe FunctionsFramework::Function do
   it "represents an http function using a block" do
     tester = self
-    function = FunctionsFramework::Function.new "my_func", :http do |request|
+    function = FunctionsFramework::Function.http "my_func" do |request|
       tester.assert_equal "the-request", request
-      tester.assert_equal "my_func", context[:function_name]
+      tester.assert_equal "my_func", global(:function_name)
       "hello"
     end
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.new_call.call "the-request"
+    response = function.call "the-request", globals: { function_name: function.name }
     assert_equal "hello", response
   end
 
   it "represents an http function using a block with a return statement" do
-    function = FunctionsFramework::Function.new "my_func", :http do |request|
+    function = FunctionsFramework::Function.http "my_func" do |request|
       return "hello" if request == "the-request"
       "goodbye"
     end
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.new_call.call "the-request"
+    response = function.call "the-request"
     assert_equal "hello", response
   end
 
@@ -44,12 +44,12 @@ describe FunctionsFramework::Function do
     tester = self
     function = FunctionsFramework::Function.new "my_event_func", :cloud_event do |event|
       tester.assert_equal "the-event", event
-      tester.assert_equal "my_event_func", context[:function_name]
+      tester.assert_equal "my_event_func", global(:function_name)
       "ok"
     end
     assert_equal "my_event_func", function.name
     assert_equal :cloud_event, function.type
-    function.new_call.call "the-event"
+    function.call "the-event", globals: { function_name: function.name }
   end
 
   it "represents an http function using an object" do
@@ -60,7 +60,7 @@ describe FunctionsFramework::Function do
     function = FunctionsFramework::Function.new "my_func", :http, callable
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.new_call.call "the-request"
+    response = function.call "the-request"
     assert_equal "hello", response
   end
 
@@ -77,7 +77,7 @@ describe FunctionsFramework::Function do
     function = FunctionsFramework::Function.new "my_func", :http, MyCallable
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.new_call.call "the-request"
+    response = function.call "the-request"
     assert_equal "hello", response
   end
 end

--- a/test/test_main.rb
+++ b/test/test_main.rb
@@ -33,12 +33,10 @@ describe FunctionsFramework do
     begin
       last_error = nil
       retry_count.times do
-        begin
-          return yield
-        rescue ::SystemCallError => e
-          last_error = e
-          sleep retry_interval
-        end
+        return yield
+      rescue ::SystemCallError => e
+        last_error = e
+        sleep retry_interval
       end
       raise last_error
     ensure

--- a/test/test_main.rb
+++ b/test/test_main.rb
@@ -1,0 +1,103 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+require "net/http"
+require "uri"
+
+require "functions_framework"
+
+describe FunctionsFramework do
+  let(:retry_count) { 10 }
+  let(:retry_interval) { 0.5 }
+  let(:port) { "8066" }
+  let(:timeout) { 10 }
+
+  def run_with_retry target
+    server = FunctionsFramework.start target do |config|
+      config.port = port
+      config.show_error_details = true
+    end
+    begin
+      last_error = nil
+      retry_count.times do
+        begin
+          return yield
+        rescue ::SystemCallError => e
+          last_error = e
+          sleep retry_interval
+        end
+      end
+      raise last_error
+    ensure
+      server.stop.wait_until_stopped timeout: timeout
+    end
+  end
+
+  before do
+    @saved_registry = FunctionsFramework.global_registry
+    FunctionsFramework.global_registry = FunctionsFramework::Registry.new
+  end
+
+  after do
+    FunctionsFramework.global_registry = @saved_registry
+  end
+
+  it "defines and runs an http function" do
+    FunctionsFramework.http "return_http" do |request|
+      "I received a #{request.request_method} request: #{request.url}"
+    end
+    response = nil
+    capture_subprocess_io do
+      response = run_with_retry "return_http" do
+        Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
+      end
+    end
+    assert_equal "200", response.code
+    assert_equal "I received a GET request: http://127.0.0.1:#{port}/", response.body
+  end
+
+  it "defines and runs a startup task and a http function" do
+    FunctionsFramework.on_startup do
+      set_global :foo, :bar
+    end
+    FunctionsFramework.http "return_http" do
+      "foo is #{global(:foo).inspect}"
+    end
+    response = nil
+    capture_subprocess_io do
+      response = run_with_retry "return_http" do
+        Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
+      end
+    end
+    assert_equal "200", response.code
+    assert_equal "foo is :bar", response.body
+  end
+
+  it "freezes globals in a function" do
+    FunctionsFramework.http "return_http" do |request|
+      set_global :foo, :bar
+      "I received a #{request.request_method} request: #{request.url}"
+    end
+    response = nil
+    capture_subprocess_io do
+      response = run_with_retry "return_http" do
+        Net::HTTP.get_response URI("http://127.0.0.1:#{port}/")
+      end
+    end
+    assert_equal "500", response.code
+    assert_match(/FrozenError: can't modify frozen Hash/, response.body)
+  end
+end

--- a/test/test_registry.rb
+++ b/test/test_registry.rb
@@ -83,4 +83,12 @@ describe FunctionsFramework::Registry do
     assert task_completed
     assert_equal :bar, globals[:foo]
   end
+
+  it "defines a function without a formal parameter" do
+    registry.add_http "my_func" do
+      "hello"
+    end
+    response = registry["my_func"].call "the-request"
+    assert_equal "hello", response
+  end
 end

--- a/test/test_registry.rb
+++ b/test/test_registry.rb
@@ -33,7 +33,7 @@ describe FunctionsFramework::Registry do
     function = registry["my_func"]
     assert_equal "my_func", function.name
     assert_equal :http, function.type
-    response = function.new_call.call "the-request"
+    response = function.call "the-request"
     assert_equal "hello", response
   end
 
@@ -47,7 +47,7 @@ describe FunctionsFramework::Registry do
     function = registry["my_func"]
     assert_equal "my_func", function.name
     assert_equal :cloud_event, function.type
-    function.new_call.call "the-event"
+    function.call "the-event"
   end
 
   it "defines multiple functions" do
@@ -63,22 +63,24 @@ describe FunctionsFramework::Registry do
   end
 
   it "defines startup tasks" do
-    expected_rack_env = "google"
     tester = self
     task_completed = false
     registry.add_http "func1" do |_request|
       "hello"
     end
     function = registry["func1"]
-    registry.add_startup_task do |func, config|
+    registry.add_startup_task do |func|
       tester.assert_same function, func
-      tester.assert_equal expected_rack_env, config.rack_env
       task_completed = true
+      set_global :foo, :bar
     end
-    server = FunctionsFramework::Server.new function do |config|
-      config.rack_env = expected_rack_env
-    end
-    registry.run_startup_tasks server
+    tasks = registry.startup_tasks
+    assert_equal 1, tasks.size
+    task = tasks.first
+    assert_equal :startup_task, task.type
+    globals = {}
+    task.call function, globals: globals
     assert task_completed
+    assert_equal :bar, globals[:foo]
   end
 end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -59,11 +59,10 @@ describe FunctionsFramework::Server do
     server.start
     last_error = nil
     retry_count.times do
-      begin
-        return yield
-      rescue ::SystemCallError => e
-        last_error = e
-      end
+      return yield
+    rescue ::SystemCallError => e
+      last_error = e
+      sleep retry_interval
     end
     raise last_error
   ensure
@@ -78,15 +77,13 @@ describe FunctionsFramework::Server do
   end
 
   it "starts and stops" do
-    begin
-      refute http_server.running?
-      http_server.start
-      assert http_server.running?
-      http_server.stop.wait_until_stopped timeout: 10
-      refute http_server.running?
-    ensure
-      http_server.stop.wait_until_stopped timeout: 10
-    end
+    refute http_server.running?
+    http_server.start
+    assert http_server.running?
+    http_server.stop.wait_until_stopped timeout: 10
+    refute http_server.running?
+  ensure
+    http_server.stop.wait_until_stopped timeout: 10
   end
 
   it "handles post requests" do

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -41,9 +41,10 @@ describe FunctionsFramework::Server do
   let(:event_server) { make_basic_server event_function }
   let(:retry_count) { 10 }
   let(:retry_interval) { 0.5 }
+  let(:app_context) { ::Hash.new }
 
   def make_basic_server function
-    FunctionsFramework::Server.new function do |config|
+    FunctionsFramework::Server.new function, app_context do |config|
       config.min_threads = 1
       config.max_threads = 1
       config.port = port
@@ -70,7 +71,7 @@ describe FunctionsFramework::Server do
   end
 
   it "supports configuration in a constructor block" do
-    server = FunctionsFramework::Server.new http_function do |config|
+    server = FunctionsFramework::Server.new http_function, app_context do |config|
       config.rack_env = "my-env"
     end
     assert_equal "my-env", server.config.rack_env

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -21,6 +21,7 @@ describe FunctionsFramework::Testing do
   let(:simple_http_path) { File.join __dir__, "function_definitions", "simple_http.rb" }
   let(:simple_event_path) { File.join __dir__, "function_definitions", "simple_event.rb" }
   let(:return_http_path) { File.join __dir__, "function_definitions", "return_http.rb" }
+  let(:startup_block_path) { File.join __dir__, "function_definitions", "startup_block.rb" }
 
   describe "#make_request" do
     it "creates a PUT request" do
@@ -186,6 +187,44 @@ describe FunctionsFramework::Testing do
           FunctionsFramework::Testing.call_event "simple_event", event
         end
         assert_match(/I received "Hello, world!" in an event of type event-type/, err)
+      end
+    end
+  end
+
+  describe "#run_startup_tasks" do
+    it "runs startup tasks" do
+      FunctionsFramework::Testing.load_temporary startup_block_path do
+        out, _err = capture_subprocess_io do
+          FunctionsFramework::Testing.run_startup_tasks "simple_http"
+        end
+        assert_equal "in startup block\n", out
+        request = FunctionsFramework::Testing.make_get_request "http://example.com/"
+        response = FunctionsFramework::Testing.call_http "simple_http", request
+        assert_equal "OK", response.body.join
+      end
+    end
+
+    it "runs automatically" do
+      FunctionsFramework::Testing.load_temporary startup_block_path do
+        request = FunctionsFramework::Testing.make_get_request "http://example.com/"
+        response = nil
+        out, _err = capture_subprocess_io do
+          response = FunctionsFramework::Testing.call_http "simple_http", request
+        end
+        assert_equal "in startup block\n", out
+        assert_equal "OK", response.body.join
+      end
+    end
+
+    it "refuses to run repeatedly" do
+      FunctionsFramework::Testing.load_temporary startup_block_path do
+        request = FunctionsFramework::Testing.make_get_request "http://example.com/"
+        capture_subprocess_io do
+          FunctionsFramework::Testing.call_http "simple_http", request
+        end
+        assert_raises "Function simple_http has already started up" do
+          FunctionsFramework::Testing.run_startup_tasks "simple_http"
+        end
       end
     end
   end


### PR DESCRIPTION
A set of changes toward better support for shared resources such as remote service clients, after working on writing samples against the initial interfaces. Specifically:

* Now requires Ruby 2.5 or later.
* Renamed "context" hash to "globals" and made it read-only for normal functions.
* Startup blocks are no longer passed the server config.
* Provided a "logger" convenience method in the context object.
* Globals can be set from startup blocks, which is useful for initializing shared resources.
* Support for testing startup tasks in the Testing module.
* Support for controlling logging in the Testing module.
* Fixed crash introduced in 0.6 when a block didn't declare an expected argument.
* Better support for running concurrent tests.
* Expanded documentation on initialization, execution context, and shared resources.
