### PR TITLE
chore: Fix reporting of conventional commit lint issues

### DIFF
--- a/.github/workflows/release-hook-on-open.yml
+++ b/.github/workflows/release-hook-on-open.yml
@@ -1,7 +1,7 @@
 name: "[release hook] Check commit messages"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Check commit messages

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,6 +23,9 @@ jobs:
             ruby: "2.7"
             flags: "--no-test-rubocop"
           - os: ubuntu-latest
+            ruby: head
+            flags: "--only --test-unit"
+          - os: ubuntu-latest
             ruby: jruby
             flags: "--only --test-unit"
           - os: macos-latest

--- a/.toys/release/.data/templates/release-hook-on-open.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-open.yml.erb
@@ -1,7 +1,7 @@
 name: "[release hook] Check commit messages"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Check commit messages

--- a/.toys/release/.lib/release_utils.rb
+++ b/.toys/release/.lib/release_utils.rb
@@ -293,7 +293,8 @@ class ReleaseUtils
       logger.info("GitHub checks disabled")
       return self
     end
-    wait_github_checks_internal(current_sha(ref), ::Time.now.to_i + required_checks_timeout)
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + required_checks_timeout
+    wait_github_checks_internal(current_sha(ref), deadline)
   end
 
   def github_check_errors(ref)
@@ -387,7 +388,7 @@ class ReleaseUtils
         return []
       end
       errors.each { |msg| logger.info(msg) }
-      if ::Time.now.to_i > deadline
+      if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
         results = ["GitHub checks still failing after #{required_checks_timeout} secs."]
         return results + errors
       end


### PR DESCRIPTION
This patch fixes the conventional commit linter action. Previously, when a PR was opened from a fork and the commit message failed linting, the checker could not post details of the problem in a PR comment as intended, because the action's token didn't have sufficient permissions. Now we use a different trigger that runs in the base repo's context, thus giving the token enough permissions to write to the PR.