### PR TITLE
release: Release functions_framework 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.8.0 / 2021-03-02
+
+* ADDED: Support for lazily-initialized globals
+
 ### v0.7.1 / 2021-01-26
 
 * DOCS: Fixed several errors in the writing-functions doc samples

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.7.1".freeze
+  VERSION = "0.8.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 0.8.0** (was 0.7.1)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v0.8.0 / 2021-03-02

* ADDED: Support for lazily-initialized globals
