### PR TITLE
fix: Conformance fixes for Firebase to CloudEvent conversions

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,15 +27,15 @@ jobs:
     - name: Bundle install
       run: 'bundle install'
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.6
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.6
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target cloudevent_func --signature-type cloudevent'"

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -112,7 +112,7 @@ module FunctionsFramework
       when "firebaseauth.googleapis.com"
         return data unless data.key? "metadata"
 
-        FIREBASE_AUTH_METADATA_LEGACTY_TO_CE.each do |old_key, new_key|
+        FIREBASE_AUTH_METADATA_LEGACY_TO_CE.each do |old_key, new_key|
           if data["metadata"].key? old_key
             data["metadata"][new_key] = data["metadata"][old_key]
             data["metadata"].delete old_key
@@ -163,7 +163,7 @@ module FunctionsFramework
     }.freeze
 
     # Map Firebase Auth legacy event metadata field names to their equivalent CloudEvent field names.
-    FIREBASE_AUTH_METADATA_LEGACTY_TO_CE = {
+    FIREBASE_AUTH_METADATA_LEGACY_TO_CE = {
       "createdAt"      => "createTime",
       "lastSignedInAt" => "lastSignInTime"
     }.freeze

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -98,7 +98,7 @@ module FunctionsFramework
     end
 
     def convert_source service, resource
-      return ["//#{service}/#{resource}", nil] unless CE_SERVICE_TO_RESOURCE_RE.key?(service)
+      return ["//#{service}/#{resource}", nil] unless CE_SERVICE_TO_RESOURCE_RE.key? service
 
       match = CE_SERVICE_TO_RESOURCE_RE[service].match resource
       return [nil, nil] unless match
@@ -108,18 +108,18 @@ module FunctionsFramework
     def convert_data service, data
       case service
       when "pubsub.googleapis.com"
-        return { "message" => data }
+        { "message" => data }
       when "firebaseauth.googleapis.com"
-        return data unless data.key?("metadata")
+        return data unless data.key? "metadata"
 
         FIREBASE_AUTH_METADATA_LEGACTY_TO_CE.each do |old_key, new_key|
-          if data["metadata"].key?(old_key)
+          if data["metadata"].key? old_key
             data["metadata"][new_key] = data["metadata"][old_key]
             data["metadata"].delete old_key
           end
         end
 
-        return data
+        data
       else
         data
       end
@@ -130,8 +130,8 @@ module FunctionsFramework
       %r{^providers/cloud\.pubsub/}    => "pubsub.googleapis.com",
       %r{^providers/cloud\.storage/}   => "storage.googleapis.com",
       %r{^providers/firebase\.auth/}   => "firebaseauth.googleapis.com",
-      %r{^providers/google\.firebase\.analytics/}  => "firebase.googleapis.com",
-      %r{^providers/google\.firebase\.database/}  => "firebasedatabase.googleapis.com"
+      %r{^providers/google\.firebase\.analytics/} => "firebase.googleapis.com",
+      %r{^providers/google\.firebase\.database/} => "firebasedatabase.googleapis.com"
     }.freeze
 
     LEGACY_TYPE_TO_CE_TYPE = {

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -36,8 +36,6 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-18T12:13:19+00:00", event.time.rfc3339
     assert_equal "value1", event.data["message"]["attributes"]["attribute1"]
     assert_equal "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl", event.data["message"]["data"]
-    assert event.data.key? "subscription" # Exists but not yet set.
-    assert_nil event.data["subscription"]
   end
 
   it "converts legacy_storage_change.json" do
@@ -61,8 +59,6 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "attr1-value", event.data["message"]["attributes"]["attr1"]
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
-    assert event.data.key? "subscription" # Exists but not yet set.
-    assert_nil event.data["subscription"]
   end
 
   it "converts pubsub_binary.json" do
@@ -74,8 +70,6 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_nil event.subject
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "AQIDBA==", event.data["message"]["data"]
-    assert event.data.key? "subscription" # Exists but not yet set.
-    assert_nil event.data["subscription"]
   end
 
   it "converts storage.json" do
@@ -94,10 +88,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "1.0", event.spec_version
     assert_equal "7b8f1804-d38b-4b68-b37d-e2fb5d12d5a0-0", event.id
     assert_equal \
-      "//firestore.googleapis.com/projects/project-id/databases/(default)/documents/gcf-test/2Vm2mI1d0wIaK2Waj5to",
+      "//firestore.googleapis.com/projects/project-id/databases/(default)",
       event.source.to_s
     assert_equal "google.cloud.firestore.document.v1.written", event.type
-    assert_nil event.subject
+    assert_equal "documents/gcf-test/2Vm2mI1d0wIaK2Waj5to", event.subject
     assert_equal "2020-04-23T12:00:27+00:00", event.time.rfc3339
     assert_equal "bar", event.data["value"]["fields"]["foo"]["stringValue"]
   end
@@ -107,10 +101,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "1.0", event.spec_version
     assert_equal "9babded5-e5f2-41af-a46a-06ba6bd84739-0", event.id
     assert_equal \
-      "//firestore.googleapis.com/projects/project-id/databases/(default)/documents/gcf-test/IH75dRdeYJKd4uuQiqch",
+      "//firestore.googleapis.com/projects/project-id/databases/(default)",
       event.source.to_s
     assert_equal "google.cloud.firestore.document.v1.written", event.type
-    assert_nil event.subject
+    assert_equal "documents/gcf-test/IH75dRdeYJKd4uuQiqch", event.subject
     assert_equal "2020-04-23T14:25:05+00:00", event.time.rfc3339
     assert_equal "50", event.data["value"]["fields"]["intValue"]["integerValue"]
   end
@@ -119,7 +113,7 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-auth1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "4423b4fa-c39b-4f79-b338-977a018e9b55", event.id
-    assert_equal "//firebase.googleapis.com/projects/my-project-id", event.source.to_s
+    assert_equal "//firebaseauth.googleapis.com/projects/my-project-id", event.source.to_s
     assert_equal "google.firebase.auth.user.v1.created", event.type
     assert_nil event.subject
     assert_equal "2020-05-26T10:42:27+00:00", event.time.rfc3339
@@ -130,7 +124,7 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-auth2.json"
     assert_equal "1.0", event.spec_version
     assert_equal "5fd71bdc-4955-421f-9fc3-552ac3abead8", event.id
-    assert_equal "//firebase.googleapis.com/projects/my-project-id", event.source.to_s
+    assert_equal "//firebaseauth.googleapis.com/projects/my-project-id", event.source.to_s
     assert_equal "google.firebase.auth.user.v1.deleted", event.type
     assert_nil event.subject
     assert_equal "2020-05-26T10:47:14+00:00", event.time.rfc3339
@@ -141,7 +135,7 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-db1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "/SnHth9OSlzK1Puj85kk4tDbF90=", event.id
-    assert_equal "//firebase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz", event.source.to_s
+    assert_equal "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz", event.source.to_s
     assert_equal "google.firebase.database.document.v1.written", event.type
     assert_nil event.subject
     assert_equal "2020-05-21T11:15:34+00:00", event.time.rfc3339

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -135,9 +135,9 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-db1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "/SnHth9OSlzK1Puj85kk4tDbF90=", event.id
-    assert_equal "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id/refs/gcf-test/xyz", event.source.to_s
+    assert_equal "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id", event.source.to_s
     assert_equal "google.firebase.database.document.v1.written", event.type
-    assert_nil event.subject
+    assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:15:34+00:00", event.time.rfc3339
     assert_equal "other", event.data["delta"]["grandchild"]
   end


### PR DESCRIPTION
Also enable legacy to CloudEvent mapping validation in conformance test config.