### PR TITLE
fix: Set correct CloudEvent subject when converting a Firebase Auth event

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,13 +27,13 @@ jobs:
     - name: Bundle install
       run: 'bundle install'
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.8
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.8
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,7 @@ jobs:
             flags: "--only --test-unit"
           - os: ubuntu-latest
             ruby: "2.7"
-            flags: "--no-test-rubocop"
+            flags: "--only --test-unit"
           - os: ubuntu-latest
             ruby: "3.0"
             flags: "--only --test-unit"
@@ -34,6 +34,9 @@ jobs:
           - os: windows-latest
             ruby: "2.7"
             flags: "--only --test-unit"
+          - os: ubuntu-latest
+            ruby: "2.7"
+            flags: "--only --test-yardoc --test-build --test-examples"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -14,7 +14,7 @@
 
 desc "Run CI checks"
 
-TESTS = ["unit", "rubocop", "yardoc", "build", "examples"]
+TESTS = ["unit", "rubocop", "yardoc", "build", "examples", "conformance"]
 
 flag :only
 TESTS.each do |name|
@@ -39,13 +39,13 @@ def run
     key = "test_#{name}".to_sym
     set key, !only if get(key).nil?
   end
-  exec ["toys", "test"], name: "Tests" if test_unit
+  exec ["toys", "test"], name: "Unit tests" if test_unit
   exec ["toys", "rubocop"], name: "Style checker" if test_rubocop
   exec ["toys", "yardoc"], name: "Docs generation" if test_yardoc
   exec ["toys", "build"], name: "Gem build" if test_build
-  return unless test_examples
   ::Dir.foreach "examples" do |dir|
     next if dir =~ /^\.+$/
     exec ["toys", "test"], name: "Tests for #{dir} example", chdir: ::File.join("examples", dir)
-  end
+  end if test_examples
+  exec ["toys", "conformance"], name: "Conformance tests" if test_conformance
 end

--- a/.toys/conformance.rb
+++ b/.toys/conformance.rb
@@ -1,0 +1,38 @@
+
+static :github_url, "https://github.com/GoogleCloudPlatform/functions-framework-conformance.git"
+
+flag :keep_output
+
+include :fileutils
+include :exec, e: true
+
+def run
+  mkdir_p "tmp"
+  cd "tmp" do
+    unless File.directory? "functions-framework-conformance"
+      exec ["git", "clone", github_url]
+    end
+    cd "functions-framework-conformance" do
+      exec ["git", "pull"]
+      exec ["go", "build"], chdir: "client"
+    end
+  end
+  begin
+    exec ["tmp/functions-framework-conformance/client/client",
+          "-cmd", "bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http",
+          "-type=http",
+          "-builder-source=testdata",
+          "-buildpacks=false"]
+    exec ["tmp/functions-framework-conformance/client/client",
+          "-cmd", "bundle exec functions-framework-ruby --source test/conformance/app.rb --target cloudevent_func --signature-type cloudevent",
+          "-type=cloudevent",
+          "-validate-mapping=true",
+          "-buildpacks=false"]
+  ensure
+    unless keep_output
+      rm_f "function_output.json"
+      rm_f "serverlog_stderr.txt"
+      rm_f "serverlog_stdout.txt"
+    end
+  end
+end

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -115,7 +115,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "4423b4fa-c39b-4f79-b338-977a018e9b55", event.id
     assert_equal "//firebaseauth.googleapis.com/projects/my-project-id", event.source.to_s
     assert_equal "google.firebase.auth.user.v1.created", event.type
-    assert_nil event.subject
+    assert_equal "users/UUpby3s4spZre6kHsgVSPetzQ8l2", event.subject
     assert_equal "2020-05-26T10:42:27+00:00", event.time.rfc3339
     assert_equal "test@nowhere.com", event.data["email"]
   end
@@ -126,7 +126,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "5fd71bdc-4955-421f-9fc3-552ac3abead8", event.id
     assert_equal "//firebaseauth.googleapis.com/projects/my-project-id", event.source.to_s
     assert_equal "google.firebase.auth.user.v1.deleted", event.type
-    assert_nil event.subject
+    assert_equal "users/UUpby3s4spZre6kHsgVSPetzQ8l2", event.subject
     assert_equal "2020-05-26T10:47:14+00:00", event.time.rfc3339
     assert_equal "test@nowhere.com", event.data["email"]
   end


### PR DESCRIPTION
Included:

* Update the legacy event converter to set the subject for firebase auth events
* Update the legacy event converter unit tests accordingly
* Added a toys script to run the conformance tests, and add it to the CI script
* Update the conformance action version tag to 0.3.8
* Tweak the unit test github action to split out build, yardoc, and example tests into a separate job for easier review.