### PR TITLE
release: Release functions_framework 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v0.9.0 / 2021-03-18
+
+* BREAKING CHANGE: Servers are configured as single-threaded in production by default
+
+* FIXED: Conformance fixes for Firebase to CloudEvent conversions 
+* FIXED: Set correct CloudEvent subject when converting a Firebase Auth event
+* FIXED: Fixed an error when setting a global to a Minitest::Mock
+* FIXED: Servers are configured as single-threaded in production by default
+
 ### v0.8.0 / 2021-03-02
 
 * ADDED: Support for lazily-initialized globals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ### v0.9.0 / 2021-03-18
 
-* BREAKING CHANGE: Servers are configured as single-threaded in production by default
-
-* FIXED: Conformance fixes for Firebase to CloudEvent conversions 
-* FIXED: Set correct CloudEvent subject when converting a Firebase Auth event
-* FIXED: Fixed an error when setting a global to a Minitest::Mock
-* FIXED: Servers are configured as single-threaded in production by default
+* BREAKING CHANGE: Servers are configured as single-threaded in production by default, matching the current behavior of Google Cloud Functions.
+* FIXED: Fixed conversion of Firebase events to CloudEvents to conform to the specs used by Cloud Functions and Cloud Run.
+* FIXED: Fixed an error when reading a global set to a Minitest::Mock. This will make it easier to write tests that use mocks for global resources.
 
 ### v0.8.0 / 2021-03-02
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Create a `Gemfile` listing the Functions Framework as a dependency:
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.8"
+gem "functions_framework", "~> 0.9"
 ```
 
 Create a file called `app.rb` and include the following code. This defines a

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -64,7 +64,7 @@ Create a `Gemfile` listing the Functions Framework as a dependency:
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.8"
+gem "functions_framework", "~> 0.9"
 ```
 
 Create a file called `app.rb` and include the following code. This defines a

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -111,7 +111,7 @@ dependency on Sinatra in your `Gemfile`:
 
 ```ruby
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.8"
+gem "functions_framework", "~> 0.9"
 gem "sinatra", "~> 2.0"
 ```
 
@@ -470,7 +470,7 @@ Following is a typical layout for a Functions Framework based project.
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.8"
+gem "functions_framework", "~> 0.9"
 ```
 
 ```ruby

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.8.0".freeze
+  VERSION = "0.9.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 0.9.0** (was 0.8.0)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v0.9.0 / 2021-03-18

* BREAKING CHANGE: Servers are configured as single-threaded in production by default

* FIXED: Conformance fixes for Firebase to CloudEvent conversions 
* FIXED: Set correct CloudEvent subject when converting a Firebase Auth event
* FIXED: Fixed an error when setting a global to a Minitest::Mock
* FIXED: Servers are configured as single-threaded in production by default
