### PR TITLE
fix: Set the charset when autogenerating a content-type for a response

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7, 3.0]
+        ruby-version: ["2.5", "2.6", "2.7", "3.0"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #95 