### PR TITLE
fix: Properly handle conversion of non-ascii characters in legacy event strings

### DIFF
--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -45,8 +45,8 @@ version = ::FunctionsFramework::VERSION
   spec.executables = ["functions-framework", "functions-framework-ruby"]
 
   spec.required_ruby_version = ">= 2.5.0"
-  spec.add_dependency "cloud_events", "~> 0.1"
-  spec.add_dependency "puma", "~> 4.3"
+  spec.add_dependency "cloud_events", ">= 0.4", "< 2.a"
+  spec.add_dependency "puma", ">= 4.3.0", "< 6.a"
   spec.add_dependency "rack", "~> 2.1"
 
   if spec.respond_to? :metadata

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -27,7 +27,7 @@ module FunctionsFramework
     # @return [nil] if the event format was not recognized.
     #
     def decode_rack_env env
-      content_type = ::CloudEvents::ContentType.new env["CONTENT_TYPE"]
+      content_type = ::CloudEvents::ContentType.new env["CONTENT_TYPE"], default_charset: "utf-8"
       return nil unless content_type.media_type == "application" && content_type.subtype_base == "json"
       input = read_input_json env["rack.input"], content_type.charset
       return nil unless input

--- a/test/legacy_events_data/pubsub_utf8.json
+++ b/test/legacy_events_data/pubsub_utf8.json
@@ -1,0 +1,19 @@
+{
+   "context": {
+      "eventId":"1144231683168617",
+      "timestamp":"2020-05-06T07:33:34.556Z",
+      "eventType":"google.pubsub.topic.publish",
+      "resource":{
+        "service":"pubsub.googleapis.com",
+        "name":"projects/sample-project/topics/gcf-test",
+        "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+      }
+   },
+   "data": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+         "attr1":"あああ"
+      },
+      "data": "dGVzdCBtZXNzYWdlIDM="
+   }
+}

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -61,6 +61,18 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
   end
 
+  it "converts pubsub_utf8.json" do
+    event = load_legacy_event "pubsub_utf8.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "1144231683168617", event.id
+    assert_equal "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test", event.source.to_s
+    assert_equal "google.cloud.pubsub.topic.v1.messagePublished", event.type
+    assert_nil event.subject
+    assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
+    assert_equal "あああ", event.data["message"]["attributes"]["attr1"]
+    assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
+  end
+
   it "converts pubsub_binary.json" do
     event = load_legacy_event "pubsub_binary.json"
     assert_equal "1.0", event.spec_version


### PR DESCRIPTION
Fixes #97 