### PR TITLE
release: Release functions_framework 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v0.10.0 / 2021-06-01
+
+* ADDED: Support raw pubsub events sent by the pubsub emulator 
+* FIXED: Set proper response content-type charset 
+* FIXED: Properly handle conversion of non-ascii characters in legacy event strings 
+* FIXED: Properly handle conversion of non-ascii characters in legacy event strings
+
 ### v0.9.0 / 2021-03-18
 
 * BREAKING CHANGE: Servers are configured as single-threaded in production by default, matching the current behavior of Google Cloud Functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ### v0.10.0 / 2021-06-01
 
-* ADDED: Support raw pubsub events sent by the pubsub emulator 
-* FIXED: Set proper response content-type charset 
-* FIXED: Properly handle conversion of non-ascii characters in legacy event strings 
+* ADDED: Support raw pubsub events sent by the pubsub emulator
+* FIXED: Set proper response content-type charset when a function returns a string (plain text) or hash (JSON)
 * FIXED: Properly handle conversion of non-ascii characters in legacy event strings
 
 ### v0.9.0 / 2021-03-18

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.9.0".freeze
+  VERSION = "0.10.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 0.10.0** (was 0.9.0)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v0.10.0 / 2021-06-01

* ADDED: Support raw pubsub events sent by the pubsub emulator 
* FIXED: Set proper response content-type charset 
* FIXED: Properly handle conversion of non-ascii characters in legacy event strings 
* FIXED: Properly handle conversion of non-ascii characters in legacy event strings
