### PR TITLE
Update firebasedatabase event conversion logic

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,7 +33,7 @@ jobs:
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.11
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -117,7 +117,7 @@ module FunctionsFramework
       source, subject = convert_source context[:service], context[:resource]
       type = LEGACY_TYPE_TO_CE_TYPE[context[:type]]
       return nil unless type && source
-      ce_data, data_subject = convert_data context[:service], data
+      ce_data, data_subject = convert_data context, data
       content_type = "application/json"
       ::CloudEvents::Event.new id:                context[:id],
                                source:            source,
@@ -137,9 +137,12 @@ module FunctionsFramework
       ["//#{service}/#{match[1]}", match[2]]
     end
 
-    def convert_data service, data
+    def convert_data context, data
+      service = context[:service]
       case service
       when "pubsub.googleapis.com"
+        data["messageId"] = data["message_id"] = context[:id]
+        data["publishTime"] = data["publish_time"] = context[:timestamp]
         [{ "message" => data }, nil]
       when "firebaseauth.googleapis.com"
         if data.key? "metadata"

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -141,8 +141,8 @@ module FunctionsFramework
       service = context[:service]
       case service
       when "pubsub.googleapis.com"
-        data["messageId"] = data["message_id"] = context[:id]
-        data["publishTime"] = data["publish_time"] = context[:timestamp]
+        data["messageId"] = context[:id]
+        data["publishTime"] = context[:timestamp]
         [{ "message" => data }, nil]
       when "firebaseauth.googleapis.com"
         if data.key? "metadata"

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -37,9 +37,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "value1", event.data["message"]["attributes"]["attribute1"]
     assert_equal "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl", event.data["message"]["data"]
     assert_equal "1215011316659232", event.data["message"]["messageId"]
-    assert_equal "1215011316659232", event.data["message"]["message_id"]
     assert_equal "2020-05-18T12:13:19.209Z", event.data["message"]["publishTime"]
-    assert_equal "2020-05-18T12:13:19.209Z", event.data["message"]["publish_time"]
     assert_nil event.data["subscription"]
   end
 
@@ -65,9 +63,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "attr1-value", event.data["message"]["attributes"]["attr1"]
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
     assert_equal "1144231683168617", event.data["message"]["messageId"]
-    assert_equal "1144231683168617", event.data["message"]["message_id"]
     assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
-    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts pubsub_utf8.json" do
@@ -81,9 +77,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "あああ", event.data["message"]["attributes"]["attr1"]
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
     assert_equal "1144231683168617", event.data["message"]["messageId"]
-    assert_equal "1144231683168617", event.data["message"]["message_id"]
     assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
-    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts pubsub_binary.json" do
@@ -96,9 +90,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "AQIDBA==", event.data["message"]["data"]
     assert_equal "1144231683168617", event.data["message"]["messageId"]
-    assert_equal "1144231683168617", event.data["message"]["message_id"]
     assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
-    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts raw_pubsub.json" do
@@ -112,10 +104,8 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
     assert_equal "1215011316659232", event.data["message"]["messageId"]
-    assert_equal "1215011316659232", event.data["message"]["message_id"]
     timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
     assert_equal timestamp, event.data["message"]["publishTime"]
-    assert_equal timestamp, event.data["message"]["publish_time"]
   end
 
   it "converts raw_pubsub.json with path" do
@@ -129,10 +119,8 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
     assert_equal "1215011316659232", event.data["message"]["messageId"]
-    assert_equal "1215011316659232", event.data["message"]["message_id"]
     timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
     assert_equal timestamp, event.data["message"]["publishTime"]
-    assert_equal timestamp, event.data["message"]["publish_time"]
   end
 
   it "converts storage.json" do

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -104,7 +104,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
     assert_equal "1215011316659232", event.data["message"]["messageId"]
-    timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
+    timestamp = event.time.to_time.utc.strftime "%Y-%m-%dT%H:%M:%S.%6NZ"
     assert_equal timestamp, event.data["message"]["publishTime"]
   end
 
@@ -119,7 +119,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
     assert_equal "1215011316659232", event.data["message"]["messageId"]
-    timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
+    timestamp = event.time.to_time.utc.strftime "%Y-%m-%dT%H:%M:%S.%6NZ"
     assert_equal timestamp, event.data["message"]["publishTime"]
   end
 

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -36,6 +36,11 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-18T12:13:19+00:00", event.time.rfc3339
     assert_equal "value1", event.data["message"]["attributes"]["attribute1"]
     assert_equal "VGhpcyBpcyBhIHNhbXBsZSBtZXNzYWdl", event.data["message"]["data"]
+    assert_equal "1215011316659232", event.data["message"]["messageId"]
+    assert_equal "1215011316659232", event.data["message"]["message_id"]
+    assert_equal "2020-05-18T12:13:19.209Z", event.data["message"]["publishTime"]
+    assert_equal "2020-05-18T12:13:19.209Z", event.data["message"]["publish_time"]
+    assert_nil event.data["subscription"]
   end
 
   it "converts legacy_storage_change.json" do
@@ -59,6 +64,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "attr1-value", event.data["message"]["attributes"]["attr1"]
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
+    assert_equal "1144231683168617", event.data["message"]["messageId"]
+    assert_equal "1144231683168617", event.data["message"]["message_id"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts pubsub_utf8.json" do
@@ -71,6 +80,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "あああ", event.data["message"]["attributes"]["attr1"]
     assert_equal "dGVzdCBtZXNzYWdlIDM=", event.data["message"]["data"]
+    assert_equal "1144231683168617", event.data["message"]["messageId"]
+    assert_equal "1144231683168617", event.data["message"]["message_id"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts pubsub_binary.json" do
@@ -82,6 +95,10 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_nil event.subject
     assert_equal "2020-05-06T07:33:34+00:00", event.time.rfc3339
     assert_equal "AQIDBA==", event.data["message"]["data"]
+    assert_equal "1144231683168617", event.data["message"]["messageId"]
+    assert_equal "1144231683168617", event.data["message"]["message_id"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publishTime"]
+    assert_equal "2020-05-06T07:33:34.556Z", event.data["message"]["publish_time"]
   end
 
   it "converts raw_pubsub.json" do
@@ -94,6 +111,11 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_in_delta event.time.to_time.to_f, Time.now.to_f, 1.0
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
+    assert_equal "1215011316659232", event.data["message"]["messageId"]
+    assert_equal "1215011316659232", event.data["message"]["message_id"]
+    timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
+    assert_equal timestamp, event.data["message"]["publishTime"]
+    assert_equal timestamp, event.data["message"]["publish_time"]
   end
 
   it "converts raw_pubsub.json with path" do
@@ -106,6 +128,11 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_in_delta event.time.to_time.to_f, Time.now.to_f, 1.0
     assert_equal "123", event.data["message"]["attributes"]["test"]
     assert_equal "eyJmb28iOiJiYXIifQ==", event.data["message"]["data"]
+    assert_equal "1215011316659232", event.data["message"]["messageId"]
+    assert_equal "1215011316659232", event.data["message"]["message_id"]
+    timestamp = event.time.to_time.utc.strftime("%Y-%m-%dT%H:%M:%S.%6NZ")
+    assert_equal timestamp, event.data["message"]["publishTime"]
+    assert_equal timestamp, event.data["message"]["publish_time"]
   end
 
   it "converts storage.json" do


### PR DESCRIPTION
Recently the format of Firebase RTDB cloudevent was updated to include location information in the source. When upcasting, this can be derived from the domain field of a legacy event as described [here](https://github.com/GoogleCloudPlatform/functions-framework-conformance/blob/master/docs/mapping.md#firebase-rtdb-events-tentative).

This commit also updates the Functions Framework Conformance Github action to a version that tests this logic.