### PR TITLE
Update firebasedatabase event conversion logic

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,13 +27,13 @@ jobs:
     - name: Bundle install
       run: 'bundle install'
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.11
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -84,10 +84,11 @@ module FunctionsFramework
       id = normalized_context_field input, "eventId"
       timestamp = normalized_context_field input, "timestamp"
       type = normalized_context_field input, "eventType"
+      domain = normalized_context_field input, "domain"
       service, resource = analyze_resource normalized_context_field input, "resource"
       service ||= service_from_type type
       return nil unless id && timestamp && type && service && resource
-      { id: id, timestamp: timestamp, type: type, service: service, resource: resource }
+      { id: id, timestamp: timestamp, type: type, service: service, resource: resource, domain: domain }
     end
 
     def normalized_context_field input, field
@@ -114,7 +115,7 @@ module FunctionsFramework
     end
 
     def construct_cloud_event context, data
-      source, subject = convert_source context[:service], context[:resource]
+      source, subject = convert_source context[:service], context[:resource], context[:domain]
       type = LEGACY_TYPE_TO_CE_TYPE[context[:type]]
       return nil unless type && source
       ce_data, data_subject = convert_data context, data
@@ -129,12 +130,20 @@ module FunctionsFramework
                                time:              context[:timestamp]
     end
 
-    def convert_source service, resource
+    def convert_source service, resource, domain
       return ["//#{service}/#{resource}", nil] unless CE_SERVICE_TO_RESOURCE_RE.key? service
 
       match = CE_SERVICE_TO_RESOURCE_RE[service].match resource
       return [nil, nil] unless match
-      ["//#{service}/#{match[1]}", match[2]]
+      
+      if service == "firebasedatabase.googleapis.com"
+        raise "Invalid firebasedatabase event: domain is nil" if domain == nil
+        location = "us-central1"
+        location = domain.split(".")[0] if domain != "firebaseio.com"
+        ["//#{service}/projects/_/locations/#{location}/#{match[1]}", match[2]]
+      else
+        ["//#{service}/#{match[1]}", match[2]]
+      end
     end
 
     def convert_data context, data
@@ -192,7 +201,7 @@ module FunctionsFramework
 
     CE_SERVICE_TO_RESOURCE_RE = {
       "firebase.googleapis.com"         => %r{^(projects/[^/]+)/(events/[^/]+)$},
-      "firebasedatabase.googleapis.com" => %r{^(projects/_/instances/[^/]+)/(refs/.+)$},
+      "firebasedatabase.googleapis.com" => %r{^projects/_/(instances/[^/]+)/(refs/.+)$},
       "firestore.googleapis.com"        => %r{^(projects/[^/]+/databases/\(default\))/(documents/.+)$},
       "storage.googleapis.com"          => %r{^(projects/[^/]+/buckets/[^/]+)/([^#]+)(?:#.*)?$}
     }.freeze

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -137,9 +137,13 @@ module FunctionsFramework
       return [nil, nil] unless match
 
       if service == "firebasedatabase.googleapis.com"
-        raise "Invalid firebasedatabase event: domain is nil" if domain.nil?
+        return [nil, nil] if domain.nil?
         location = "us-central1"
-        location = domain.split(".")[0] if domain != "firebaseio.com"
+        if domain != "firebaseio.com"
+          location_match = domain.match(/^([\w-]+)\.firebasedatabase\.app$/)
+          return [nil, nil] unless location_match
+          location = location_match[1]
+        end
         ["//#{service}/projects/_/locations/#{location}/#{match[1]}", match[2]]
       else
         ["//#{service}/#{match[1]}", match[2]]

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -135,9 +135,9 @@ module FunctionsFramework
 
       match = CE_SERVICE_TO_RESOURCE_RE[service].match resource
       return [nil, nil] unless match
-      
+
       if service == "firebasedatabase.googleapis.com"
-        raise "Invalid firebasedatabase event: domain is nil" if domain == nil
+        raise "Invalid firebasedatabase event: domain is nil" if domain.nil?
         location = "us-central1"
         location = domain.split(".")[0] if domain != "firebaseio.com"
         ["//#{service}/projects/_/locations/#{location}/#{match[1]}", match[2]]

--- a/test/legacy_events_data/firebase-db1.json
+++ b/test/legacy_events_data/firebase-db1.json
@@ -6,6 +6,7 @@
   "auth": {
     "admin": true
   },
+  "domain":"firebaseio.com",
   "data": {
     "data": null,
     "delta": {

--- a/test/legacy_events_data/firebase-dbdelete1.json
+++ b/test/legacy_events_data/firebase-dbdelete1.json
@@ -6,6 +6,7 @@
   "auth": {
     "admin": true
   },
+  "domain":"europe-west1.firebasedatabase.app",
   "data": {
     "data": {
       "grandchild": "other changed"

--- a/test/legacy_events_data/firebase-dbdelete2.json
+++ b/test/legacy_events_data/firebase-dbdelete2.json
@@ -6,6 +6,7 @@
   "auth": {
     "admin": true
   },
+  "domain":"firebaseio.com",
   "data": {
     "data": 10,
     "delta": null

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -186,10 +186,20 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-db1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "/SnHth9OSlzK1Puj85kk4tDbF90=", event.id
-    assert_equal "//firebasedatabase.googleapis.com/projects/_/instances/my-project-id", event.source.to_s
+    assert_equal "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id", event.source.to_s
     assert_equal "google.firebase.database.document.v1.written", event.type
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:15:34+00:00", event.time.rfc3339
     assert_equal "other", event.data["delta"]["grandchild"]
+  end
+
+  it "converts firebase-dbdelete1.json" do
+    event = load_legacy_event "firebase-dbdelete1.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "oIcVXHEMZfhQMNs/yD4nwpuKE0s=", event.id
+    assert_equal "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id", event.source.to_s
+    assert_equal "google.firebase.database.document.v1.deleted", event.type
+    assert_equal "refs/gcf-test/xyz", event.subject
+    assert_equal "2020-05-21T11:53:45+00:00", event.time.rfc3339
   end
 end

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -186,7 +186,9 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-db1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "/SnHth9OSlzK1Puj85kk4tDbF90=", event.id
-    assert_equal "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id", event.source.to_s
+    assert_equal \
+      "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+      event.source.to_s
     assert_equal "google.firebase.database.document.v1.written", event.type
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:15:34+00:00", event.time.rfc3339
@@ -197,7 +199,9 @@ describe FunctionsFramework::LegacyEventConverter do
     event = load_legacy_event "firebase-dbdelete1.json"
     assert_equal "1.0", event.spec_version
     assert_equal "oIcVXHEMZfhQMNs/yD4nwpuKE0s=", event.id
-    assert_equal "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id", event.source.to_s
+    assert_equal \
+      "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
+      event.source.to_s
     assert_equal "google.firebase.database.document.v1.deleted", event.type
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:53:45+00:00", event.time.rfc3339

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -206,4 +206,16 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:53:45+00:00", event.time.rfc3339
   end
+
+  it "converts firebase-dbdelete2.json" do
+    event = load_legacy_event "firebase-dbdelete2.json"
+    assert_equal "1.0", event.spec_version
+    assert_equal "KVLKeFKjFP2jepddr+EPGC0ZQ20=", event.id
+    assert_equal \
+      "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+      event.source.to_s
+    assert_equal "google.firebase.database.document.v1.deleted", event.type
+    assert_equal "refs/gcf-test/abc", event.subject
+    assert_equal "2020-05-21T11:56:12+00:00", event.time.rfc3339
+  end
 end


### PR DESCRIPTION
Recently the format of Firebase RTDB cloudevent was updated to include location information in the source. When upcasting, this can be derived from the domain field of a legacy event as described [here](https://github.com/GoogleCloudPlatform/functions-framework-conformance/blob/master/docs/mapping.md#firebase-rtdb-events-tentative).

This commit also updates the Functions Framework Conformance Github action to a version that tests this logic.