### PR TITLE
release: Release functions_framework 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ### v0.11.0 / 2021-06-28
 
-* FIXED: Updated the Pub/Sub event conversion logic to better align to Eventarc 
-* FIXED: Update CloudEvents dependency 
-* FIXED: Loosen firebasedatabase domain restriction in legacy event conversion 
+* UPDATED: Update CloudEvents dependency to 0.5 to get fixes for JSON formatting cases
+* FIXED: Updated Pub/Sub and Firebase event conversion logic to better align to Eventarc
 
 ### v0.10.0 / 2021-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v0.11.0 / 2021-06-28
+
+* FIXED: Updated the Pub/Sub event conversion logic to better align to Eventarc 
+* FIXED: Update CloudEvents dependency 
+* FIXED: Loosen firebasedatabase domain restriction in legacy event conversion 
+
 ### v0.10.0 / 2021-06-01
 
 * ADDED: Support raw pubsub events sent by the pubsub emulator

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.10.0".freeze
+  VERSION = "0.11.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 0.11.0** (was 0.10.0)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v0.11.0 / 2021-06-28

* FIXED: Updated the Pub/Sub event conversion logic to better align to Eventarc 
* FIXED: Update CloudEvents dependency 
* FIXED: Loosen firebasedatabase domain restriction in legacy event conversion
