### PR TITLE
release: Release functions_framework 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.0.0 / 2021-07-07
+
+* Bumping the version to 1.0. No significant changes.
+
 ### v0.11.0 / 2021-06-28
 
 * UPDATED: Update CloudEvents dependency to 0.5 to get fixes for JSON formatting cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### v1.0.0 / 2021-07-07
 
-* Bumping the version to 1.0. No significant changes.
+* Bumped the version to 1.0.
+* Removed the "preview" notices for Google Cloud Functions since the Ruby runtime is now GA.
 
 ### v0.11.0 / 2021-06-28
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An open source framework for writing lightweight, portable Ruby functions that
 run in a serverless environment. Functions written to this Framework will run
 in many different environments, including:
 
- *  [Google Cloud Functions](https://cloud.google.com/functions) *(public preview)*
+ *  [Google Cloud Functions](https://cloud.google.com/functions)
  *  [Google Cloud Run](https://cloud.google.com/run)
  *  Any other [Knative](https://github.com/knative)-based environment
  *  Your local development machine
@@ -60,7 +60,7 @@ Create a `Gemfile` listing the Functions Framework as a dependency:
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.11"
+gem "functions_framework", "~> 1.0"
 ```
 
 Create a file called `app.rb` and include the following code. This defines a

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,7 +8,7 @@ The Functions Framework is an open source framework for writing lightweight,
 portable Ruby functions that run in a serverless environment. Functions written
 to this Framework will run in many different environments, including:
 
- *  [Google Cloud Functions](https://cloud.google.com/functions) *(public preview)*
+ *  [Google Cloud Functions](https://cloud.google.com/functions)
  *  [Google Cloud Run](https://cloud.google.com/run)
  *  Any other [Knative](https://github.com/knative)-based environment
  *  Your local development machine
@@ -64,7 +64,7 @@ Create a `Gemfile` listing the Functions Framework as a dependency:
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.11"
+gem "functions_framework", "~> 1.0"
 ```
 
 Create a file called `app.rb` and include the following code. This defines a

--- a/docs/writing-functions.md
+++ b/docs/writing-functions.md
@@ -111,7 +111,7 @@ dependency on Sinatra in your `Gemfile`:
 
 ```ruby
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.11"
+gem "functions_framework", "~> 1.0"
 gem "sinatra", "~> 2.0"
 ```
 
@@ -152,7 +152,7 @@ information about it:
 require "functions_framework"
 
 FunctionsFramework.cloud_event "hello" do |event|
-  FunctionsFramework.logger.info "I received an event of type #{event.type}!"
+  logger.info "I received an event of type #{event.type}!"
 end
 ```
 
@@ -470,7 +470,7 @@ Following is a typical layout for a Functions Framework based project.
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem "functions_framework", "~> 0.11"
+gem "functions_framework", "~> 1.0"
 ```
 
 ```ruby

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "0.11.0".freeze
+  VERSION = "1.0.0".freeze
 end


### PR DESCRIPTION
This pull request prepares new gem releases for the following gems:

 *  **functions_framework 1.0.0** (was 0.11.0)

For each gem, this pull request modifies the gem version and provides an initial changelog entry based on [conventional commit](https://conventionalcommits.org) messages. You can edit these changes before merging, to release a different version or to alter the changelog text.

You can run the `release perform` script once these changes are merged.

The generated changelog entries have been copied below:

----

## functions_framework

### v1.0.0 / 2021-07-07

* (No significant changes)
