### PR TITLE
fix: Update legacy event conversion to set the correct types for firebase database events

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,13 +27,13 @@ jobs:
     - name: Bundle install
       run: 'bundle install'
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -45,7 +45,7 @@ version = ::FunctionsFramework::VERSION
   spec.executables = ["functions-framework", "functions-framework-ruby"]
 
   spec.required_ruby_version = ">= 2.5.0"
-  spec.add_dependency "cloud_events", ">= 0.5.1", "< 2.a"
+  spec.add_dependency "cloud_events", ">= 0.6.0", "< 2.a"
   spec.add_dependency "puma", ">= 4.3.0", "< 6.a"
   spec.add_dependency "rack", "~> 2.1"
 

--- a/lib/functions_framework/legacy_event_converter.rb
+++ b/lib/functions_framework/legacy_event_converter.rb
@@ -200,10 +200,10 @@ module FunctionsFramework
       "providers/firebase.auth/eventTypes/user.create"           => "google.firebase.auth.user.v1.created",
       "providers/firebase.auth/eventTypes/user.delete"           => "google.firebase.auth.user.v1.deleted",
       "providers/google.firebase.analytics/eventTypes/event.log" => "google.firebase.analytics.log.v1.written",
-      "providers/google.firebase.database/eventTypes/ref.create" => "google.firebase.database.document.v1.created",
-      "providers/google.firebase.database/eventTypes/ref.write"  => "google.firebase.database.document.v1.written",
-      "providers/google.firebase.database/eventTypes/ref.update" => "google.firebase.database.document.v1.updated",
-      "providers/google.firebase.database/eventTypes/ref.delete" => "google.firebase.database.document.v1.deleted",
+      "providers/google.firebase.database/eventTypes/ref.create" => "google.firebase.database.ref.v1.created",
+      "providers/google.firebase.database/eventTypes/ref.write"  => "google.firebase.database.ref.v1.written",
+      "providers/google.firebase.database/eventTypes/ref.update" => "google.firebase.database.ref.v1.updated",
+      "providers/google.firebase.database/eventTypes/ref.delete" => "google.firebase.database.ref.v1.deleted",
       "providers/cloud.storage/eventTypes/object.change"         => "google.cloud.storage.object.v1.finalized"
     }.freeze
 

--- a/test/test_legacy_event_converter.rb
+++ b/test/test_legacy_event_converter.rb
@@ -200,7 +200,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal \
       "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
       event.source.to_s
-    assert_equal "google.firebase.database.document.v1.written", event.type
+    assert_equal "google.firebase.database.ref.v1.written", event.type
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:15:34+00:00", event.time.rfc3339
     assert_equal "other", event.data["delta"]["grandchild"]
@@ -213,7 +213,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal \
       "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
       event.source.to_s
-    assert_equal "google.firebase.database.document.v1.deleted", event.type
+    assert_equal "google.firebase.database.ref.v1.deleted", event.type
     assert_equal "refs/gcf-test/xyz", event.subject
     assert_equal "2020-05-21T11:53:45+00:00", event.time.rfc3339
   end
@@ -225,7 +225,7 @@ describe FunctionsFramework::LegacyEventConverter do
     assert_equal \
       "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
       event.source.to_s
-    assert_equal "google.firebase.database.document.v1.deleted", event.type
+    assert_equal "google.firebase.database.ref.v1.deleted", event.type
     assert_equal "refs/gcf-test/abc", event.subject
     assert_equal "2020-05-21T11:56:12+00:00", event.time.rfc3339
   end


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/functions-framework-conformance/pull/79