### PR TITLE
docs: add buildpack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here is how to build and run a deployable container on your local machine.
 	```sh
 	pack build \
 		--builder gcr.io/buildpacks/builder:v1 \
+		--env GOOGLE_RUNTIME=ruby \
 		--env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
 		--env GOOGLE_FUNCTION_TARGET=hello \
 		my-first-function


### PR DESCRIPTION
Temp PR for adding buildpack instructions. (blocked by 197273799)

This PR can be re-opened when unblocked.