### PR TITLE
Format the error backtrace

### DIFF
--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -352,7 +352,9 @@ module FunctionsFramework
         when ::CloudEvents::CloudEventsError
           cloud_events_error_response response
         when ::StandardError
-          error_response "#{response.class}: #{response.message}\n#{response.backtrace}\n"
+          message = "#{response.class}: #{response.message}"
+          message = [message, *response.backtrace].join "\n\t"
+          error_response message
         else
           error_response "Unexpected response type: #{response.class}"
         end

--- a/lib/functions_framework/testing.rb
+++ b/lib/functions_framework/testing.rb
@@ -335,7 +335,8 @@ module FunctionsFramework
           json = ::JSON.dump response
           string_response json, 200, content_type: "application/json"
         when ::StandardError
-          message = "#{response.class}: #{response.message}\n#{response.backtrace}\n"
+          message = "#{response.class}: #{response.message}"
+          message = [message, *response.backtrace].join "\n\t"
           string_response message, 500
         else
           raise "Unexpected response type: #{response.inspect}"

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -244,7 +244,7 @@ describe FunctionsFramework::Server do
       ::Net::HTTP.get_response URI("#{server_url}/")
     end
     assert_equal "500", response.code
-    assert_match(/Whoops!/, response.body)
+    assert_match(/RuntimeError: Whoops!\n\t#{__FILE__}/, response.body)
     assert_equal "text/plain; charset=utf-8", response["Content-Type"]
   end
 


### PR DESCRIPTION
An error's backtrace is an array, and the formatter isn't taking that into consideration. Here's what an error currently looks like:

```
E, [2021-11-29T00:31:23.035715 #41693] ERROR -- : RuntimeError: Boom
["/path/to/app.rb:12:in `block in <top (required)>'", "/path/to/functions_framework-1.0.1/lib/functions_framework/function.rb:164:in `call'", "/path/to/functions_framework-1.0.1/lib/functions_framework/server.rb:407:in `call'", "/path/to/puma-5.5.2/lib/puma/request.rb:77:in `block in handle_request'", "/path/to/puma-5.5.2/lib/puma/thread_pool.rb:340:in `with_force_shutdown'", "/path/to/puma-5.5.2/lib/puma/request.rb:76:in `handle_request'", "/path/to/puma-5.5.2/lib/puma/server.rb:447:in `process_client'", "/path/to/puma-5.5.2/lib/puma/thread_pool.rb:147:in `block in spawn_thread'"]
```

This PR makes it so that the error is logged like so:

```
E, [2021-11-29T00:32:17.242192 #44604] ERROR -- : RuntimeError: Boom
	/path/to/app.rb:12:in `block in <top (required)>'
	/path/to/functions_framework/function.rb:164:in `call'
	/path/to/functions_framework/server.rb:407:in `call'
	/path/to/puma-5.5.2/lib/puma/request.rb:77:in `block in handle_request'
	/path/to/puma-5.5.2/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
	/path/to/puma-5.5.2/lib/puma/request.rb:76:in `handle_request'
	/path/to/puma-5.5.2/lib/puma/server.rb:447:in `process_client'
	/path/to/puma-5.5.2/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
```