### PR TITLE
feat: Increase default max thread pool size to 8

### DIFF
--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -306,7 +306,7 @@ module FunctionsFramework
       # @return [Integer]
       #
       def max_threads
-        @max_threads || 1
+        @max_threads || 8
       end
 
       ##


### PR DESCRIPTION
This will allow some concurrency on deployment options that support it.

The value of 8 is chosen based on Ruby best practices to provide enough concurrency to prevent IO-bound requests from blocking too much, while keeping GVL contention down. MRI is not designed for massive parallelism.

In the future, we can also consider supporting worker forking. We do not do so right now to keep memory use stable.