### PR TITLE
build: switch to release-please tagging

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,3 +3,4 @@ releaseType: ruby
 bumpMinorPreMajor: true
 packageName: functions_framework
 monorepoTags: true
+handleGHRelease: true

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,1 @@
+enabled: true


### PR DESCRIPTION
https://github.com/googleapis/repo-automation-bots/tree/main/packages/release-trigger will handle triggering the actual release job (uses same logic internally)