### PR TITLE
chore: Disable cloud-rad build for now

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -12,4 +12,4 @@ python3 -m pip install gcp-docuploader
 gem install --no-document toys
 
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
-toys release perform -v --enable-docs --enable-rad < /dev/null
+toys release perform -v --enable-docs < /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## 1.1.0 (2022-01-17)
-
-* Increase default max thread pool size to 8.
-* Return 204 when a GET request is sent to an event function, to support health checks.
-* Flush stdout and stderr streams at the end of each request.
-* Format the error backtrace.
-
 ## 1.0.1 (2021-09-10)
 
 * FIXED: Update legacy event conversion to set the correct types for firebase database events

--- a/lib/functions_framework/version.rb
+++ b/lib/functions_framework/version.rb
@@ -17,5 +17,5 @@ module FunctionsFramework
   # Version of the Ruby Functions Framework
   # @return [String]
   #
-  VERSION = "1.1.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
Also reverts the 1.1.0 release commit so we can try again with the new release-please tagger.