### PR TITLE
chore: CI - unit.yml - move bundle install into ruby/setup-ruby, use PS in Windows

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,17 +15,17 @@ jobs:
         ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1"]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
+        check-latest: true
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Bundle install
-      run: 'bundle install'
+        bundler-cache: true
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.6.0
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.0"
-    - name: Install dependencies
-      run: "bundle install && gem install --no-document toys"
+        bundler-cache: true
+    - name: Install toys
+      run: gem install --no-document toys
     - name: Lint
       run: "toys ci --only --test-rubocop"

--- a/.github/workflows/push-gh-pages.yml
+++ b/.github/workflows/push-gh-pages.yml
@@ -10,14 +10,15 @@ jobs:
       ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Install Ruby ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: "gem install --no-document toys && bundle install"
+          bundler-cache: true
+      - name: Install toys
+        run: gem install --no-document toys
       - name: Publish docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -47,14 +47,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1.112.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ matrix.ruby }}"
-    - name: Install dependencies
-      shell: bash
-      run: "bundle install && gem install --no-document toys"
+        bundler-cache: true
+    - name: Install toys
+      run: gem install --no-document toys
     - name: Test ${{ matrix.flags }}
       shell: bash
       run: toys ci ${{ matrix.flags }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "**/Gemfile"
     - "*.gemspec"
   Exclude:
+    - "**/vendor/bundle/**/*"
     - "examples/*/vendor/**/*.rb"
 
 Lint/ConstantDefinitionInBlock:


### PR DESCRIPTION
1. ruby/setup-ruby - use `bundler-cache: true`, remove `bundle install` from other steps
2. actions/checkout@v2 -> actions/checkout@v3
3. actions/setup-go@v2 -> actions/setup-go@v3

