### PR TITLE
chore: Add Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+        ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,6 +40,9 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.0"
             flags: "--only --test-yardoc --test-build --test-examples"
+          - os: ubuntu-latest
+            ruby: "3.2"
+            flags: "--only --test-unit"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Ruby 3.2 goes Public Preview for GCF and GAE next week (starting 02/27).