### PR TITLE
fix: Support puma 6 and rack 3

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -14,7 +14,7 @@
 
 desc "Run CI checks"
 
-TESTS = ["unit", "rubocop", "yardoc", "build", "examples", "conformance"]
+TESTS = ["unit", "dependencies", "rubocop", "yardoc", "build", "examples", "conformance"]
 
 flag :only
 TESTS.each do |name|
@@ -26,26 +26,68 @@ include :terminal
 
 def handle_result result
   if result.success?
-    puts "** #{result.name} passed\n\n", :green, :bold
+    puts "** Passed: #{result.name}\n\n", :green, :bold
   else
-    puts "** CI terminated: #{result.name} failed!", :red, :bold
-    exit 1
+    puts "** Failed: #{result.name}\n\n", :red, :bold
+    @errors << result.name
   end
 end
 
 def run
+  @errors = []
   ::Dir.chdir context_directory
   TESTS.each do |name|
     key = "test_#{name}".to_sym
     set key, !only if get(key).nil?
   end
-  exec ["toys", "test"], name: "Unit tests" if test_unit
-  exec ["toys", "rubocop"], name: "Style checker" if test_rubocop
-  exec ["toys", "yardoc"], name: "Docs generation" if test_yardoc
-  exec ["toys", "build"], name: "Gem build" if test_build
+  exec_separate_tool ["test"], name: "Unit tests" if test_unit
+  exec_separate_tool ["ci", "deps-matrix"], name: "Dependency matrix tests" if test_dependencies
+  exec_separate_tool ["rubocop"], name: "Style checker" if test_rubocop
+  exec_separate_tool ["yardoc"], name: "Docs generation" if test_yardoc
+  exec_separate_tool ["build"], name: "Gem build" if test_build
   ::Dir.foreach "examples" do |dir|
     next if dir =~ /^\.+$/
-    exec ["toys", "test"], name: "Tests for #{dir} example", chdir: ::File.join("examples", dir)
+    exec_separate_tool ["test"], name: "Tests for #{dir} example", chdir: ::File.join("examples", dir)
   end if test_examples
-  exec ["toys", "conformance"], name: "Conformance tests" if test_conformance
+  exec_separate_tool ["conformance"], name: "Conformance tests" if test_conformance
+  @errors.each do |err|
+    puts "Failed: #{err}", :red, :bold
+  end
+  exit 1 unless @errors.empty?
+end
+
+tool "deps-matrix" do
+  static :puma_versions, ["4.0", "5.0", "6.0"]
+  static :rack_versions, ["2.1", "3.0"]
+
+  include :exec, result_callback: :handle_result
+  include :terminal
+
+  def handle_result result
+    if result.success?
+      puts "** Passed: #{result.name}\n\n", :green, :bold
+    else
+      puts "** Failed: #{result.name}\n\n", :red, :bold
+      @errors << result.name
+    end
+  end
+
+  def run
+    @errors = []
+    ::Dir.chdir context_directory
+    puma_versions.each do |puma_version|
+      rack_versions.each do |rack_version|
+        name = "Puma #{puma_version} / Rack #{rack_version}"
+        env = {
+          "FF_DEPENDENCY_TEST_PUMA" => "~> #{puma_version}",
+          "FF_DEPENDENCY_TEST_RACK" => "~> #{rack_version}",
+        }
+        exec_separate_tool ["test", "test/test_server.rb"], env: env, name: name
+      end
+    end
+    @errors.each do |err|
+      puts "Failed: #{err}", :red, :bold
+    end
+    exit 1 unless @errors.empty?
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,11 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-style", "~> 1.26.1"
+gem "google-style", "~> 1.26.3"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.2"
 gem "minitest-rg", "~> 5.2"
+gem "puma", ENV["FF_DEPENDENCY_TEST_PUMA"] if ENV["FF_DEPENDENCY_TEST_PUMA"]
+gem "rack", ENV["FF_DEPENDENCY_TEST_RACK"] if ENV["FF_DEPENDENCY_TEST_RACK"]
 gem "redcarpet", "~> 3.5" unless ::RUBY_PLATFORM == "java"
 gem "yard", "~> 0.9.25"

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -46,8 +46,8 @@ version = ::FunctionsFramework::VERSION
 
   spec.required_ruby_version = ">= 2.6.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
-  spec.add_dependency "puma", ">= 4.3.0", "< 6.a"
-  spec.add_dependency "rack", "~> 2.1"
+  spec.add_dependency "puma", ">= 4.3.0", "< 7.a"
+  spec.add_dependency "rack", ">= 2.1", "< 4.a"
 
   if spec.respond_to? :metadata
     spec.metadata["changelog_uri"] =

--- a/lib/functions_framework/testing.rb
+++ b/lib/functions_framework/testing.rb
@@ -367,8 +367,8 @@ module FunctionsFramework
           ::Rack::QUERY_STRING    => url.query,
           ::Rack::SERVER_NAME     => url.host,
           ::Rack::SERVER_PORT     => url.port,
+          ::Rack::SERVER_PROTOCOL => "HTTP/1.1",
           ::Rack::RACK_URL_SCHEME => url.scheme,
-          ::Rack::RACK_VERSION    => ::Rack::VERSION,
           ::Rack::RACK_LOGGER     => ::FunctionsFramework.logger,
           ::Rack::RACK_INPUT      => ::StringIO.new,
           ::Rack::RACK_ERRORS     => ::StringIO.new


### PR DESCRIPTION
Handles breaking changes in Puma 6 ad Rack 3, and introduces tests against the Puma and Rack support matrix (Puma 4, 5, 6 x Rack 2, 3)

Supersedes #146 