### PR TITLE
chore: fix buildpack integration tests

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   ruby30-buildpack-test:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@garethgeorge/robust-logs
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'http_func'
@@ -19,3 +19,5 @@ jobs:
       cloudevent-builder-target: 'cloudevent_func'
       prerun: 'test/conformance/prerun.sh ${{ github.sha }}'
       builder-runtime: 'ruby30'
+      conformance-client-version: '6b9698820f817dee9ac6782710dd127409e81e8b'
+      conformance-action-version: '6b9698820f817dee9ac6782710dd127409e81e8b'

--- a/test/conformance/prerun.sh
+++ b/test/conformance/prerun.sh
@@ -23,5 +23,6 @@ cat Gemfile
 sudo gem install bundler
 
 # Generate a Gemfile.lock without installing any Gems
-bundle lock --update
+sudo bundle lock --add-platform ruby
+sudo bundle lock --update
 cat Gemfile.lock


### PR DESCRIPTION
Buildpack integration tests (run as a post submit) are failing for ruby30 as sudo is required to update the bundle lock. This PR adds sudo to the commands in the `prerun.sh` script used by the conformance tests.