### PR TITLE
chore: fix buildpack integration tests

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   ruby30-buildpack-test:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.1
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'http_func'

--- a/test/conformance/prerun.sh
+++ b/test/conformance/prerun.sh
@@ -23,5 +23,5 @@ cat Gemfile
 sudo gem install bundler
 
 # Generate a Gemfile.lock without installing any Gems
-bundle lock --update
+sudo bundle lock --update
 cat Gemfile.lock


### PR DESCRIPTION
Update buildpack test workflow to use the latest version of functions-framework-conformance which includes fixes to use the latest versions of the Google Cloud buildpacks.