### PR TITLE
fix: enable typed function compatibility with http signature

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -45,22 +45,31 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
+    - name: Run Typed conformance tests
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      with:
+        functionType: 'http'
+        declarativeType: 'typed'
+        useBuildpacks: false
+        validateConcurrency: true
+        cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target typed_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: true
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target cloudevent_func --signature-type cloudevent'"
     - name: Run HTTP concurrency tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@1975792fb34ebbfa058d690666186d669d3a5977 # v1.8.0
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
       with:
         functionType: 'http'
         useBuildpacks: false
         validateConcurrency: true
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target concurrent_http_func --signature-type http'"
+    

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -45,28 +45,27 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.3
       with:
         functionType: 'http'
         useBuildpacks: false
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target http_func --signature-type http'"
     - name: Run Typed conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.3
       with:
         functionType: 'http'
         declarativeType: 'typed'
         useBuildpacks: false
-        validateConcurrency: true
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target typed_func --signature-type http'"
     - name: Run CloudEvent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.3
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: true
         cmd: "'bundle exec functions-framework-ruby --source test/conformance/app.rb --target cloudevent_func --signature-type cloudevent'"
     - name: Run HTTP concurrency tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@2f5f319c06a3531be7f75dc5acf6bd00417ff76e # v1.8.3
       with:
         functionType: 'http'
         useBuildpacks: false

--- a/lib/functions_framework/cli.rb
+++ b/lib/functions_framework/cli.rb
@@ -197,6 +197,7 @@ module FunctionsFramework
       raise "Undefined function: #{@target.inspect}" if function.nil?
       unless @signature_type.nil? ||
              (@signature_type == "http" && function.type == :http) ||
+             (@signature_type == "http" && function.type == :typed) ||
              (["cloudevent", "event"].include?(@signature_type) && function.type == :cloud_event)
         raise "Function #{@target.inspect} does not match type #{@signature_type}"
       end

--- a/test/conformance/app.rb
+++ b/test/conformance/app.rb
@@ -29,6 +29,6 @@ end
 
 FunctionsFramework.typed "typed_func" do |request|
   return {
-    :payload => request,
+    payload: request
   }
 end

--- a/test/conformance/app.rb
+++ b/test/conformance/app.rb
@@ -26,3 +26,9 @@ FunctionsFramework.http "concurrent_http_func" do
   sleep 1
   "ok"
 end
+
+FunctionsFramework.typed "typed_func" do |request|
+  return {
+    :payload => request,
+  }
+end


### PR DESCRIPTION
Validation in lib/functions_framework/cli.rb prevents `typed` functions from working with the `http` signature type which is set in production. This change enables the `typed` signature to be used on GCP.