### PR TITLE
chore: Work around an annoying rubocop change

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,5 @@ Naming/FileName:
 Style/BlockDelimiters:
   Exclude:
     - "test/**/test_*.rb"
+Style/DoubleNegation:
+  Enabled: false

--- a/lib/functions_framework/server.rb
+++ b/lib/functions_framework/server.rb
@@ -297,7 +297,7 @@ module FunctionsFramework
           if show_error_details.nil?
             !::ENV["FUNCTION_DETAILED_ERRORS"].to_s.empty?
           else
-            show_error_details ? true : false
+            !!show_error_details
           end
       end
 


### PR DESCRIPTION
The `Style/RedundantCondition` cop seems to be flagging this case now. I would argue it's a false positive, but I'm not confident that viewpoint will be popular enough to force rubocop to revert its behavior. Unfortunately there doesn't seem to be a good alternative for this functionality that isn't also flagged by rubocop. I've made the judgment call that reverting to the "double-negative" idiom is probably the best option that preserves the intent while minimizing the blast radius of disabling a rubocop check. This of course has no functional impact on the code; hence I'm classifying it as "chore:" for conventional commit purposes.