### PR TITLE
fix: Add logger dependency to gemspec

### DIFF
--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -46,7 +46,7 @@ version = ::FunctionsFramework::VERSION
 
   spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
-  spec.add_dependency "logger", "~> 1.7"
+  spec.add_dependency "logger"
   spec.add_dependency "puma", ">= 4.3.0", "< 7.a"
   spec.add_dependency "rack", ">= 2.1", "< 4.a"
 

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -46,6 +46,7 @@ version = ::FunctionsFramework::VERSION
 
   spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
+  spec.add_dependency "logger", "~> 1.7"
   spec.add_dependency "puma", ">= 4.3.0", "< 7.a"
   spec.add_dependency "rack", ">= 2.1", "< 4.a"
 


### PR DESCRIPTION
The functions_framework gem requires the [logger](https://rubygems.org/gems/logger) gem in `lib/functions_framework/cli.rb`. Under Ruby 3.4, this emits a warning:

> logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add logger to your Gemfile or gemspec to silence this warning.

This commit adds the logger gem as a dependency to the gemspec which should silence the warning message.
