### PR TITLE
feat: replace Base64 usage with `String#pack`

### DIFF
--- a/.toys/release.rb
+++ b/.toys/release.rb
@@ -40,13 +40,12 @@ tool "publish-gh-pages" do
   end
 
   def pull_gh_pages
-    require "base64"
     Dir.chdir gh_pages_dir do
       exec ["git", "init"]
       exec ["git", "config", "--local", "user.name", "Google APIs"]
       exec ["git", "config", "--local", "user.email", "googleapis-packages@google.com"]
       if github_token && !github_token.empty? && github_remote.start_with?("https://")
-        encoded_token = Base64.strict_encode64("x-access-token:#{github_token}")
+        encoded_token = ["x-access-token:#{github_token}"].pack("m0")
         log_cmd = '["git", "config", "--local", "http.https://github.com/.extraheader", "****"]'
         exec ["git", "config", "--local", "http.https://github.com/.extraheader",
               "Authorization: Basic #{encoded_token}"],

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "base64"
 gem "google-style", "~> 1.31.0"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.2"


### PR DESCRIPTION
The change here replaces the singular use of `Base64.strict_encode64` with that method’s body, `["…"].pack("m0")`, pulled [straight from the Base64 gem’s source](https://github.com/ruby/base64/blob/v0.3.0/lib/base64.rb#L282-L284).

Thanks for considering this change!