### PR TITLE
feat: Allow puma v7 and v8

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,6 @@ permissions: read-all
 
 jobs:
   conformance:
-    if: ${{ github.repository == 'GoogleCloudPlatform/functions-framework-ruby' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,10 +13,14 @@ permissions: read-all
 
 jobs:
   conformance:
+    if: ${{ github.repository == 'GoogleCloudPlatform/functions-framework-ruby' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby: ['3.1', '3.2', '3.3', '3.4']
+        puma: ['~> 6.0', '~> 7.0', '~> 8.0']
+    env:
+      FF_DEPENDENCY_TEST_PUMA: ${{ matrix.puma }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: ['3.1', '3.2', '3.3', '3.4']
-        flags: ["--only --test-unit"]
+        flags: ["--only --test-unit", "--only --test-dependencies"]
         include:
           - os: ubuntu-latest
             ruby: jruby

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -62,6 +62,10 @@ tool "deps-matrix" do
     {puma: "5.0", rack: "2.1"},
     {puma: "6.0", rack: "2.1"},
     {puma: "6.0", rack: "3.0"},
+    {puma: "7.0", rack: "2.1"},
+    {puma: "7.0", rack: "3.0"},
+    {puma: "8.0", rack: "2.1"},
+    {puma: "8.0", rack: "3.0"},
   ]
 
   include :exec, result_callback: :handle_result

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -46,7 +46,7 @@ version = ::FunctionsFramework::VERSION
 
   spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
-  spec.add_dependency "puma", ">= 4.3.0", "< 7.a"
+  spec.add_dependency "puma", ">= 4.3.0", "< 9.a"
   spec.add_dependency "rack", ">= 2.1", "< 4.a"
 
   if spec.respond_to? :metadata


### PR DESCRIPTION
The following vulnerabilities have been reported in `puma`:

- https://github.com/advisories/GHSA-qpgp-93vx-g8v8
- https://github.com/advisories/GHSA-2vqw-3mp8-cgmx

To address these vulnerabilities, `puma` needs to be upgraded to version 7.2.1 or 8.0.2.

However, the runtime dependency in `functions_framework.gemspec` currently restricts the installation to `puma` 6.x.

https://github.com/GoogleCloudPlatform/functions-framework-ruby/blob/3ad9d448c50cf43c02d9d8a36dbcf29c603664c7/functions_framework.gemspec#L49

Therefore, I have updated the dependency to allow `puma` versions up to 8.x.