### PR TITLE
feat: Support Ruby 4.0

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
         puma: ['~> 6.0', '~> 7.0', '~> 8.0']
     env:
       FF_DEPENDENCY_TEST_PUMA: ${{ matrix.puma }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
         flags: ["--only --test-unit", "--only --test-dependencies"]
         include:
           - os: ubuntu-latest

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -47,6 +47,7 @@ version = ::FunctionsFramework::VERSION
   spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
   spec.add_dependency "logger", ">= 1.2.7.1", "< 2.a"
+  spec.add_dependency "ostruct", ">= 0.1.0", "< 1.a"
   spec.add_dependency "puma", ">= 4.3.0", "< 9.a"
   spec.add_dependency "rack", ">= 2.1", "< 4.a"
 

--- a/functions_framework.gemspec
+++ b/functions_framework.gemspec
@@ -46,6 +46,7 @@ version = ::FunctionsFramework::VERSION
 
   spec.required_ruby_version = ">= 3.1.0"
   spec.add_dependency "cloud_events", ">= 0.7.0", "< 2.a"
+  spec.add_dependency "logger", ">= 1.2.7.1", "< 2.a"
   spec.add_dependency "puma", ">= 4.3.0", "< 9.a"
   spec.add_dependency "rack", ">= 2.1", "< 4.a"
 


### PR DESCRIPTION
Currently, the latest version of Ruby is the 4.0 series.

Running the code on Ruby 4.0.x results in the following error:

```
$ toys ci
/Users/sue445/workspace/github.com/GoogleCloudPlatform/functions-framework-ruby/lib/functions_framework.rb:15: warning: logger used to be loaded from the st
You can add logger to your Gemfile or gemspec to fix this error.
/Users/sue445/.rbenv/versions/4.0.2/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- logger (LoadError)
```

```
$ toys ci
test/test_function.rb:16: warning: ostruct used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add ostruct to your Gemfile or gemspec to fix this error.
/Users/sue445/.rbenv/versions/4.0.2/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- ostruct (LoadError)
```

This is caused by `logger` and `ostruct` being promoted from default gems to bundled gems in Ruby 4.0.0.

https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-updates

Therefore, I have added these gems as runtime dependencies.