### PR TITLE
ci: fix workflow and linting failures

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,9 @@ jobs:
           release-assets.githubusercontent.com:443
           rubygems.org:443
           storage.googleapis.com:443
+          sum.golang.org:443
+          go.dev:443
+          dl.google.com:443
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,6 +24,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            api.deps.dev:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/test/test_function.rb
+++ b/test/test_function.rb
@@ -160,7 +160,7 @@ describe FunctionsFramework::Function do
         IntValue.new json.to_i
       end
 
-      def to_json(*_args)
+      def to_json *_args
         get.to_s
       end
 


### PR DESCRIPTION
This PR fixes several CI failures that recently appeared:
1. **RuboCop**: A new RuboCop release started flagging parentheses in `test_function.rb`. Removed them to fix the `Style/MethodDefParentheses` violation.
2. **Harden Runner**: The `conformance` and `dependency-review` jobs were failing due to blocked outbound network requests. Added `sum.golang.org`, `go.dev`, `dl.google.com`, and `api.deps.dev` to the allowed endpoints for `step-security/harden-runner`.